### PR TITLE
Implements #1 with SpIOpen_Frame internal library

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+ColumnLimit: 120
+IndentWidth: 4

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "SpIOpen Dev Container",
+    "dockerFile": "dockerfile",
+    "extensions": [
+      "ms-vscode.cmake-tools",
+      "cnshenj.vscode-task-manager",
+      "xaver.clang-format",
+      "anysphere.cpptools",
+      "matepek.vscode-catch2-test-adapter",
+      "anysphere.remote-ssh"
+    ],
+    "settings": {
+      "lldb.launch.terminal": "integrated",
+      "cmake.configureOnOpen": true,  
+      "terminal.integrated.shell.linux": "/bin/bash",
+      "editor.defaultFormatter": "xaver.clang-format",
+      "editor.formatOnSave": true,
+      "clang-format.style": "file" 
+    },
+        "postCreateCommand": [
+          "/bin/bash",
+          "-c",
+          "export LC_ALL=C.UTF-8 && export LANG=C.UTF-8",
+          "apt-get update && apt-get install -y gdb-multiarch"
+    ],
+    "remoteEnv": {
+    "FREERTOS_PATH": "${containerWorkspaceFolder}/modules/FreeRTOS", 
+    "FREERTOS_POSIX_PATH": "${containerWorkspaceFolder}/modules/FreeRTOS-POSIX"
+    }
+  }

--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,0 +1,60 @@
+FROM ubuntu:22.04
+
+# Install base tools
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y \
+    build-essential \
+    cmake \
+    gdb \
+    git \
+    python3 \
+    python3-pip \
+    python3-venv \
+    ninja-build \
+    gperf \
+    dfu-util \
+    libncurses5-dev \
+    libncursesw5-dev \
+    clang-format \
+    flex \
+    bison \
+    gperf \
+    wget \
+    unzip \
+    libgtest-dev \  
+    googletest && \ 
+    cd /usr/src/googletest && cmake . && make && cp lib/*.a /usr/lib && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Kconfig tools (for menuconfig, guiconfig, etc.)
+RUN pip3 install kconfiglib cpplint cmake-format
+
+# Install ARM toolchain for Pi Pico (RP2040) and general ARM
+# RUN apt-get update && apt-get install -y gcc-arm-none-eabi gdb-multiarch && \
+#     # Pico SDK (clone and set path)
+#     git clone -b master https://github.com/raspberrypi/pico-sdk.git /opt/pico-sdk && \
+#     cd /opt/pico-sdk && git submodule update --init
+
+# Install toolchain for Pi Compute Module (ARM Linux cross-compile, if not native)
+# RUN apt-get install -y gcc-arm-linux-gnueabihf
+
+# Install ESP-IDF for ESP32
+# ENV IDF_PATH=/opt/esp-idf
+# RUN git clone -b v5.1.2 --recursive https://github.com/espressif/esp-idf.git $IDF_PATH && \
+#     cd $IDF_PATH && \
+#     ./install.sh esp32 && \
+#     echo "source $IDF_PATH/export.sh" >> /root/.bashrc
+
+# If using Zephyr: Install west and Zephyr base
+# Uncomment if your project uses Zephyr (supports all your boards with Kconfig)
+# RUN pip3 install west && \
+#     west init /opt/zephyrproject && \
+#     cd /opt/zephyrproject && west update && \
+#     west zephyr-export && \
+#     pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt && \
+#     echo "source /opt/zephyrproject/.venv/bin/activate" >> /root/.bashrc && \
+#     echo "source /opt/zephyrproject/zephyr/zephyr-env.sh" >> /root/.bashrc
+
+# ENV PICO_SDK_PATH=/opt/pico-sdk
+ENV GTEST_PATH="/usr/src/googletest/googlemock/gtest:${PATH}"
+WORKDIR /workspace

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@
 
 # debug information files
 *.dwo
+/Libraries/SpIOpen_Frame/build
+Libraries/SpIOpen_Frame/.config
+Libraries/SpIOpen_Frame/include/generated/autoconf.h
+/Libraries/SpIOpen_Frame/build-tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "modules/rtos-abstraction-layer"]
+	path = modules/rtos-abstraction-layer
+	url = https://github.com/NXP/rtos-abstraction-layer.git
+[submodule "modules/embeded-template-library"]
+	path = modules/embeded-template-library
+	url = https://github.com/ETLCPP/etl.git
+[submodule "modules/FreeRTOS"]
+	path = modules/FreeRTOS
+	url = https://github.com/FreeRTOS/FreeRTOS.git
+[submodule "modules/FreeRTOS-POSIX"]
+	path = modules/FreeRTOS-POSIX
+	url = https://github.com/FreeRTOS/Lab-Project-FreeRTOS-POSIX.git

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug SpIOpen Frame Tests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/Libraries/SpIOpen_Frame/build-tests/tests/spiopen_frame_tests",
+            "cwd": "${workspaceFolder}/Libraries/SpIOpen_Frame/build-tests",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "SpIOpen Frame KConfig",
+            "type": "shell",
+            "command": "/bin/bash",
+            "args": [
+              "-l",
+              "-i",
+              "-c",
+              "cd \"${workspaceFolder}/Libraries/SpIOpen_Frame\" && menuconfig"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "presentation": {
+              "reveal": "always",
+              "panel": "dedicated",
+              "focus": true,
+              "clear": true
+            },
+            "runOptions": {
+              "reevaluateOnRerun": true
+            }
+        },
+         {
+            "label": "SpIOpen Frame Build Library Release",
+            "type": "shell",
+            "command": "cd Libraries/SpIOpen_Frame && mkdir -p build && cd build && cmake .. -D SPIOPEN_FRAME_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release && cmake --build . --config Release",
+            "group": "build",
+            "problemMatcher": ["$gcc"],
+            "presentation": { "reveal": "always" }
+         },
+         {
+            "label": "SpIOpen Frame Build Tests Debug",
+            "type": "shell",
+            "command": "cd Libraries/SpIOpen_Frame && mkdir -p build && cd build && cmake .. -D SPIOPEN_FRAME_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build . --config Debug",
+            "group": "build",
+            "problemMatcher": ["$gcc"],
+            "presentation": { "reveal": "always" }
+         },
+         {
+            "label": "SpIOpen Frame Build Tests Release",
+            "type": "shell",
+            "command": "cd Libraries/SpIOpen_Frame && mkdir -p build && cd build && cmake .. -D SPIOPEN_FRAME_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release && cmake --build . --config Release",
+            "group": "build",
+            "problemMatcher": ["$gcc"],
+            "presentation": { "reveal": "always" }
+         }
+    ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# SpIOpen Project
+
+This is a series of libraries used to enable communication between embeded devices within an industrial control fieldbus. It routes CAN frames over SPI to allow devices to use CANOpen features with a higher speed and lower cost communications bus.
+
+## Components
+- The core library centered on the communication format is located in @SpIOpen/

--- a/Libraries/SpIOpen_Frame/AGENTS.md
+++ b/Libraries/SpIOpen_Frame/AGENTS.md
@@ -1,0 +1,9 @@
+# SpIOpen
+
+This project is a platform-agnostic library to facilitate working with data frames in the SpIOpen protocol. The exact format of the protocol is detailed in @FrameFormat.md. The frame is typically held in a byte array buffer allocated from a common frame pool and also parsed into a helpful structure.
+
+## Coding Style
+- Optimize for use on resource constrained devices such as microcontrollers
+- Do not use dynamic memory allocation
+- Prefer to use tools from the embedded template library (etl namespace) instead of re-creating small helper functions or basic structures.
+- This project is coded in modern c++ (17) and generally follows google style guidelines and testing (see .clang-format at project root), although some interoperability with legacy pure-C or MISRA-C libraries is required.

--- a/Libraries/SpIOpen_Frame/AlgorithmBackend.md
+++ b/Libraries/SpIOpen_Frame/AlgorithmBackend.md
@@ -1,0 +1,69 @@
+# SpIOpen Algorithm Implementation (Compile-Time Selection)
+
+`SpIOpen_Frame` uses a small algorithm abstraction for:
+
+- CRC16-CCITT
+- CRC32 (ISO/MPEG-2)
+- SECDED(16,11) encode/decode
+
+The implementation is chosen **at compile time** by linking exactly one implementation `.cpp` file.
+
+## Public API
+
+Include the single header:
+
+- `include/spiopen_frame_algorithms.h`
+
+It declares the types and functions used by the frame writer/reader. Implementations are provided by whichever algorithm implementation source is linked (see below).
+
+## Default Implementation
+
+By default the build links the software implementation:
+
+- `src/spiopen_frame_algorithms.cpp`
+
+This uses the Embedded Template Library (ETL) for CRC and a pure-software SECDED(16,11) implementation.
+
+## Replacing With a Platform-Specific Implementation
+
+To use a hardware-accelerated or other custom implementation:
+
+1. **Implement the same API** in a new `.cpp` file. You must define these symbols in namespace `spiopen::algorithms`:
+
+   - `uint16_t ComputeCrc16C(const uint8_t* data, size_t length);`
+   - `uint32_t ComputeCrc32(const uint8_t* data, size_t length);`
+   - `uint16_t Secded16Encode11(uint16_t raw11);`
+   - `Secded16DecodeResult Secded16Decode11(uint16_t encoded16);`
+
+   The type `SecdedDecode16Result` is defined in `spiopen_frame_algorithms.h`:
+
+   ```cpp
+   struct Secded16DecodeResult {
+       uint16_t data11;
+       bool corrected;
+       bool uncorrectable;
+   };
+   ```
+
+2. **Point the build at your file** instead of the default implementation. When configuring the library, set the cache variable:
+
+   - `SPIOPEN_FRAME_ALGORITHM_SOURCE` — path to your implementation `.cpp`
+
+   Example (CMake):
+
+   ```cmake
+   set(SPIOPEN_FRAME_ALGORITHM_SOURCE
+       ${CMAKE_CURRENT_SOURCE_DIR}/platform/stm32/spiopen_frame_algorithm_stm32.cpp
+       CACHE FILEPATH "Algorithm implementation" FORCE)
+   add_subdirectory(path/to/SpIOpen_Frame)
+   ```
+
+   Or when building the library in a custom way, exclude the default algorithm `.cpp` from the build and add your own implementation file so that the linker sees exactly one definition of each algorithm function.
+
+3. **Do not link** both the default implementation and your own; exactly one implementation translation unit should be linked.
+
+## Benefits of This Pattern
+
+- **No runtime cost**: Calls to `ComputeCrc16Ccitt`, etc., resolve directly to your implementation. The compiler can inline if desired (e.g. with LTO).
+- **Smaller footprint**: No function-pointer table or dispatcher code.
+- **Familiar for embedded**: Same “one header, link the right .cpp” approach often used in C for board-support or HAL code.

--- a/Libraries/SpIOpen_Frame/CMakeLists.txt
+++ b/Libraries/SpIOpen_Frame/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.14)
+project(spiopen_frame CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Create KConfig h file from .config file, then auto-include it in the build
+execute_process(COMMAND python3 /usr/local/lib/python3.10/dist-packages/genconfig.py 
+--header-path ${CMAKE_CURRENT_SOURCE_DIR}/include/generated/autoconf.h
+WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+RESULT_VARIABLE GENCONFIG_RESULT
+ERROR_VARIABLE GENCONFIG_ERROR)
+
+if(NOT GENCONFIG_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to generate KConfig header: ${GENCONFIG_ERROR}")
+endif()
+
+add_compile_options(-imacros${CMAKE_CURRENT_SOURCE_DIR}/include/generated/autoconf.h)
+
+# Collect library sources
+file(GLOB SPIOPEN_FRAME_SOURCES "src/*.cpp")
+file(GLOB SPIOPEN_FRAME_HEADERS "include/*.h" "include/*.hpp")
+
+# Algorithm implementation is chosen at configure time
+set(SPIOPEN_FRAME_ALGORITHM_DEFAULT_IMPL "${CMAKE_CURRENT_SOURCE_DIR}/src/default/spiopen_frame_algorithms.cpp")
+set(SPIOPEN_FRAME_ALGORITHM_SOURCE "${SPIOPEN_FRAME_ALGORITHM_DEFAULT_IMPL}" CACHE FILEPATH
+    "Implementation .cpp for algorithm facade (CRC/SECDED). Replace with a platform-specific file for hardware acceleration. See AlgorithmBackend.md.")
+
+add_library(spiopen_frame STATIC ${SPIOPEN_FRAME_SOURCES} ${SPIOPEN_FRAME_ALGORITHM_SOURCE} ${SPIOPEN_FRAME_HEADERS})
+
+# Let other parts of the project see the public includes
+target_include_directories(spiopen_frame PUBLIC 
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../modules/embeded-template-library/include
+)
+
+option(SPIOPEN_FRAME_BUILD_TESTS "Build unit tests for the library" OFF)
+if(SPIOPEN_FRAME_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/Libraries/SpIOpen_Frame/FrameFormat.md
+++ b/Libraries/SpIOpen_Frame/FrameFormat.md
@@ -1,0 +1,49 @@
+The SpIOpen frame is meant to be a compact representation of any CAN, CAN-FD, or CAN-XL frame, but reconfigured for optimal throughout of SPI enabled microcontrollers. 
+* Data lengths are protected with error-correcting-codes and the entire frame is protected with cyclic redundancy checks. 
+* Bit stuffing is not required because SPI is a clock driven protocol, not a differential protocol.
+* Bit order is not as important because there is no electrical arbitration taking place
+
+The Data Format of a SpIOpen Frame:
+* [2 Bytes] Preamble : 0xAAAA
+    * Useful for finding the beginning of a new frame in a large buffer or in a PIO state machine
+* [2 Bytes] Format Header : Contains info on the rest of the header format, and everything needed to calculate the frame length
+    * Most significant byte first
+    * SECDED(16,11) : 11 bits of data hamming-encoded to 16 bits on-the-wire such that 1 error can be corrected and two can be detected. Data occupies lowest 11 bits, hamming pairty is in bits 12-15, and overall parity in bit 16.
+    * [Bits 0-3] : CAN Data Length Code ("DLC") - Along with other flags, indicated the payload length
+    * [Bit 4] : Identifier Extension ("IDE") flag - TRUE indicates that the 29-bit CID (4 Bytes) is used instead of the default 11-bit CID (2 Bytes)
+    * [Bit 5] : Flexible Data-Rate Format ("FDF") flag - TRUE indicates that CAN-FD features are available (BRS, ESI, Extended DLC)
+    * [Bit 6] : XL Format ("XLF") flag - TRUE indicates that CAN-XL features are available and the 8-Byte XL control
+    * [Bit 7] : Time to Live ("TTL") flag - TRUE Indicates that the 1 Byte TTL counter is included (and should be decremented after receipt)
+    * [Bit 8] : Word Alignment flag - TRUE indicates that the frame will be padded to ensure the total byte count is a multiple of *two*
+    * [Bit 9] : Reserved
+    * [Bit 10] : Reserved
+* [0 or 8 Bytes] XL Control (only present if XLF flag is set)
+    * [Byte 0-1] : Data Length Code, hamming encoded 11 bits into 16 bits ("DLC") - replacing earlier DLC
+    * [Byte 2] : Payload Type ("SDT")
+    * [Byte 3] : Virtual Can Network ID ("VCID")
+    * [Byte 4-7] : Addressing Field ("AF")
+* [2 or 4 Bytes] CAN Identifier ("CID") and flags
+    * Most significant byte first
+    * If Header IDE flag is *not* set (typical case) contains the 11 bit CID in 2 bytes
+    * If header IDE flag *is* set, contains the 29 bit CID in 4 bytes
+    * The most significant three bits contain additional CAN and CAN-FD flags:
+      * [Bit N] : Remote Transmition Request ("RTR") / Remote Request Substitution ("RRS") Flag
+      * [Bit N-1] : Bit Rate Switch ("BRS") flag
+      * [Bit N-2] : Error Status Indicator ("ESI") flag
+* [0 or 1 Byte] Time to Live ("TTL")
+    * Only present if header "TTL" flag is set
+    * Decremented every time the frame passes through a SpIOpen Device
+    * Useful for preventing loops, or doing relative-physical-position determination on a daisy chain bus
+* [0 to 8/64/2048 Bytes] Data
+  * IF XLF Flag : Interpret data length per XL Control Data Length Code (0-2048)
+  * ELSE IF FDF Flag : Interpret data length per 4-bit DLC {0-8, 12, 16, 20, 24, 32, 48, 64}
+  * ELSE : Interpret data length per 4-bit DLC, capped at 8 bytes
+* [0 or 1 Bytes] Padding : 0x00 IF
+* [2 or 4 Bytes] CRC
+  * CRC16 if Data Length <= 8 (CRC-16-CCITT)
+  * CRC32 if Data Length > 8 (CRC-32/MPEG-2, straight, non-reflected)
+
+Notes:
+* Reading the first 4 bytes of data after the preamble is always possible (6 is the minimum) and can always determine the length of the entire frame
+* Question: Should there be a minimum inter-packet gap?
+* Question: Should there be padding for 2-byte or 4-byte alignment to help densify hardware accelerated FIFOs, DMA, etc?

--- a/Libraries/SpIOpen_Frame/Kconfig
+++ b/Libraries/SpIOpen_Frame/Kconfig
@@ -1,0 +1,16 @@
+menu "SpIOpen Frame Library"
+
+    config SPIOPEN_FRAME_CAN_FD_ENABLE
+        bool "Support CAN-FD Frames"
+        default y
+        help
+            This enables support for CAN-FD frames, which increase the max paylaod size from 8 to 64 bytes. This is required to tunnel CAN-FD frames. This is very convenient when you have large PDOs and does not take too many extra resources with a well imlemented driver.
+
+    config SPIOPEN_FRAME_CAN_XL_ENABLE
+        bool "Support CAN-XL Frames"
+        default y
+        depends on SPIOPEN_FRAME_CAN_FD_ENABLE #XL Frames require FD frame features when tunneling
+        help
+            This enables support for CAN-XL frames, which increases the max payload size to 2048 bytes. This is required to tunnel CAN-FD frames and useful to tunnel ethernet frames. It can have negative effects on performance.
+
+endmenu

--- a/Libraries/SpIOpen_Frame/README.md
+++ b/Libraries/SpIOpen_Frame/README.md
@@ -1,0 +1,14 @@
+# SpIOpen Frame Library
+
+C++ Library for interacting with SpIOpen Frames. The format of the SpIOpen frame is defined in @FrameFormat.md.
+
+## Contents
+
+- spiopen_frame.h : contains the spiopen::Frame class which defines structured data types for representing a SpIOpen data frame
+- spiopen_frame_pool.h : contains the common frame pool which acts as the static, shared memory resource for all frames
+- spiopen_frame_router.h : contains the router responsible for moving frames between the pool, producers, and consumers using IRQ safe queues
+- spiopen_frame_producer.h : base implementation of a task that takes empty frames from the pool, populated them (based on internal processing or a physical port), then sends them back to the router for distribution to consumers.
+- spiopen_frame_consumer.h : base implementation of a task that takes populated frames from producers, processes them (either internally or onto a physical port), then frees them back to the pool.
+- spiopen_frame_parser.h : used by producers to find frames in bytestreams and get buffers from the shared memory pool
+
+## Configuration

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame.h
@@ -1,0 +1,171 @@
+/*
+SpIOpen Frame Description
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/span.h"
+#include "spiopen_frame_format.h"
+
+namespace spiopen {
+
+class Frame final {
+   public:
+    /* Structure that contains the flags for a SpIOpen frame */
+    typedef struct {
+        unsigned int RTR : 1;  // Remote Transmission Request/Remote Request Substitution flag
+        unsigned int BRS : 1;  // Bit Rate Switch flag
+        unsigned int ESI : 1;  // Error Status Indicator flag
+        unsigned int IDE : 1;  // Identifier Extension flag
+        unsigned int FDF : 1;  // Flexible Data-Rate Format flag
+        unsigned int XLF : 1;  // XL Format flag
+        unsigned int TTL : 1;  // Time to Live flag
+        unsigned int WA : 1;   // Word Alignment flag
+    } Flags;
+
+    /* Structure that contains the CAN-XL control fields*/
+    typedef struct {
+        uint8_t payload_type;
+        uint8_t virtual_can_network_id;
+        uint32_t addressing_field;
+    } XLControl;
+
+    /* Fields that represent the individual elements of the SpIOpen frame*/
+   public:
+    uint32_t can_identifier;  // 11 or 29 bit CAN identifier
+    Flags can_flags;
+    uint8_t time_to_live;  // Time to Live counter, only populated if TTL flag is set
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    XLControl xl_control;  // XL control fields, only populated if XLF flag is set
+#endif
+    etl::span<uint8_t> payload;  // Span to the payload data, only populated if payload length is non-zero. This points
+                                 // to just the underlying data and does not contain any padding. In the case of API-set
+                                 // FD payloads it might be slightly short than the on-the-wire payload pength (see
+                                 // @GetPayloadSectionLength() for the on-the-wire length that includes padding).
+
+    /* Constructor and destructor for the Frame class*/
+    inline Frame()
+        : can_identifier(0U),
+          can_flags({}),
+          time_to_live(0U),
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+          xl_control({}),
+#endif
+          payload({}) {
+    }
+    inline ~Frame() = default;
+
+    inline size_t GetCanIdLength() const {
+        return can_flags.IDE ? format::CAN_IDENTIFIER_SIZE + format::CAN_IDENTIFIER_EXTENSION_SIZE
+                             : format::CAN_IDENTIFIER_SIZE;
+    }
+
+    /* Get other information about the Frame that can be calcualted from the fields*/ public:
+    /**
+     * @brief Calculate the length of the header (not including preamble), from
+     *        the format header until right before the payload.
+     * @return The length of the header in bytes
+     */
+    inline size_t GetHeaderLength() const {
+        size_t header_length = format::FORMAT_HEADER_SIZE + GetCanIdLength();
+        if (can_flags.TTL) {
+            header_length += format::TIME_TO_LIVE_SIZE;
+        }
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+        if (can_flags.XLF) {
+            header_length += format::XL_CONTROL_SIZE + format::XL_DATA_LENGTH_SIZE;
+        }
+#endif
+        return header_length;
+    }
+
+    /**
+     * @brief Calculate the length of the payload *on the wire* in bytes, including any padding needed for FDF payloads.
+     * @return The length of the payload in bytes
+     */
+    inline bool TryGetPayloadSectionLength(size_t& payload_length_out) const {
+        if (payload.empty()) {
+            payload_length_out = 0U;
+            return true;
+        }
+
+        // CC
+        if (!can_flags.XLF && !can_flags.FDF) {
+            payload_length_out = payload.size();
+            return payload_length_out <= format::MAX_CC_PAYLOAD_SIZE;
+        }
+
+        // XL
+        if (can_flags.XLF) {
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+            payload_length_out = payload.size();
+            return payload_length_out <= format::MAX_XL_PAYLOAD_SIZE;
+#else
+            return false;
+#endif
+        }
+
+// FD
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+        uint8_t dlc = 0;
+        if (!format::TryGetDlcFromPayloadLength(payload.size(), dlc)) {
+            return false;
+        }
+        payload_length_out = format::CAN_FD_PAYLOAD_BY_DLC[dlc & format::HEADER_DLC_MASK];
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    /**
+     * @brief Calculate the length of the SpIOpen frame, from start of preamble to end of CRC, including padding
+     * @return The length of the frame in bytes
+     */
+    inline bool TryGetFrameLength(size_t& frame_length_out) const {
+        size_t payload_length = 0;
+        if (!TryGetPayloadSectionLength(payload_length)) {
+            return false;
+        }
+        size_t crc_length = format::GetCrcLengthFromPayloadLength(payload_length);
+        frame_length_out = format::PREAMBLE_SIZE + GetHeaderLength() + payload_length + crc_length;
+        if (can_flags.WA && ((frame_length_out & 0x1U) != 0U)) {
+            frame_length_out += format::MAX_PADDING_SIZE;
+        }
+        return true;
+    }
+
+    /**
+     * @brief Clears all frame fields to their default zero/empty state.
+     */
+    inline void Reset() {
+        can_identifier = 0U;
+        can_flags = {};
+        time_to_live = 0U;
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+        xl_control = {};
+#endif
+        payload = {};
+    }
+
+    /**
+     * @brief Handles decrementing the Time to Live counter if the TTL flag is set
+     * @return True if the counter is decremented and is now 0, false if TTL flag is not set or counter is above 0
+     */
+    inline bool DecrementAndCheckIfTimeToLiveExpired() {
+        if (!can_flags.TTL) {
+            return false;
+        }
+        if (time_to_live > 0U) {
+            --time_to_live;
+        }
+        return (time_to_live == 0U);
+    }
+};
+
+}  // namespace spiopen

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame_algorithms.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame_algorithms.h
@@ -1,0 +1,34 @@
+/*
+SpIOpen Frame Algorithm Facade
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+
+Single public header for CRC and SECDED algorithms. The implementation is
+chosen at compile time by linking the appropriate .cpp (see AlgorithmBackend.md).
+No runtime indirection—calls resolve directly to the linked implementation.
+*/
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/span.h"
+
+
+namespace spiopen::algorithms {
+
+struct Secded16DecodeResult {
+    uint16_t data11;
+    bool corrected;
+    bool uncorrectable;
+};
+
+uint16_t ComputeCrc16(const etl::span<const uint8_t>& data);
+uint32_t ComputeCrc32(const etl::span<const uint8_t>& data);
+
+// The goal with the SECDED encoding should be to make the "typical" path (no errors) as fast as possible.
+uint16_t Secded16Encode11(uint16_t raw11);
+Secded16DecodeResult Secded16Decode11(uint16_t encoded16);
+
+}  // namespace spiopen::algorithms

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame_buffer.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame_buffer.h
@@ -1,0 +1,104 @@
+/*
+SpIOpen Frame Buffer : Used to link a Frame object to a byte array buffer that contains the entire frame.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include "etl/byte_stream.h"
+#include "etl/span.h"
+#include "spiopen_frame.h"
+#include "spiopen_frame_reader.h"
+#include "spiopen_frame_writer.h"
+
+namespace spiopen {
+
+/**
+ * @brief Links a Frame object to a byte array buffer that contains the entire frame. The buffer may be updated by
+ * external functions (DMA, etc) requiring a re-parsing of the frame.
+ * @param buffer Pointer to the byte array buffer that is permanently allocated for this FrameBuffer object
+ * @param buffer_length Length of the byte array buffer
+ */
+class FrameBuffer {
+   public:
+    FrameBuffer(etl::span<uint8_t> buffer) : buffer_(buffer) {}
+    ~FrameBuffer() = default;
+
+    // Functions that synchronize the internal frame object with the internal buffer
+    /**
+     * @brief Writes the internal frame object to the internal buffer.
+     *
+     * If the payload points to an external buffer, the data will be copied to the internal buffer and the pointer will
+     * be adjusted to reference the internal buffer. This is useful for when an external process modifies the frame
+     * object.
+     *
+     * @return On success, void; on failure, the error code
+     */
+    etl::expected<void, frame_writer::FrameWriteError> WriteInternalBuffer() {
+        etl::byte_stream_writer writer(buffer_, etl::endian::big);
+        return frame_writer::WriteFrame(writer, frame_);
+    }
+
+    /**
+     * @brief Updates the internal frame object based on the internal buffer
+     *
+     * The payload data field of the frame object will be updated to point to somewhere within the input buffer.
+     * This is useful for when an external process fills the buffer with a new frame.
+     *
+     * @note The function may fail due to a parsing error. If it does, the internal frame object will be in an undefined
+     * state.
+     * @return On success, FrameReadResult with dlc_corrected flag; on failure, the parse error
+     */
+    etl::expected<frame_reader::FrameReadResult, frame_reader::FrameParseError> ReadInternalBuffer() {
+        etl::byte_stream_reader reader(buffer_.data(), buffer_.size(), etl::endian::big);
+        return frame_reader::ReadFrame(reader, frame_);
+    }
+
+    // Functions that set the internal fields based on external data
+    /**
+     * @brief Reads the frame from the provided buffer
+     *
+     * Reads the frame from the provided buffer, adjusting for bit slip if necessary
+     * The payload data field of the frame object will be updated to point to somewhere within the input buffer.
+     * This is useful for when an external process fills the buffer with a new frame.
+     *
+     * @note The function may fail due to a parsing error. If it does, the internal frame object will be in an undefined
+     * state.
+     * @param input_stream Byte stream reader positioned at the start of the frame (preamble). Uses big-endian.
+     * @param bit_slip_count Number of bit slips to correct for during the copy operation (positive for extra bits
+     * received, padding the most significant bits of the first byte)
+     * @return On success, FrameReadResult with dlc_corrected flag; on failure, the parse error
+     */
+    etl::expected<frame_reader::FrameReadResult, frame_reader::FrameParseError> LoadAndReadInternalBuffer(
+        etl::byte_stream_reader &input_stream, uint8_t bit_slip_count = 0) {
+        return frame_reader::ReadAndCopyFrame(input_stream, buffer_, frame_, bit_slip_count);
+    }
+
+    /**
+     * @brief Copies the provided frame object to the internal frame object, then writes the internal frame object to
+     * the internal buffer
+     *
+     * Copies the data from the provided frame object to the internal frame object, then writes the internal frame
+     * object to the internal buffer. The payload data field of the frame object will be updated to point to somewhere
+     * within the internal buffer. This is useful for when an external process finds and parses the frame from a
+     * different buffer, or creates a new frame object.
+     *
+     * @param frame Reference to the Frame object to load and write to the internal buffer
+     * @return On success, void; on failure, the error code
+     */
+    etl::expected<void, frame_writer::FrameWriteError> LoadFrameAndWriteInternalBuffer(Frame const &frame) {
+        frame_ = frame;
+        return WriteInternalBuffer();
+    }
+
+    // Getters for the internal fields
+    Frame &GetFrame() { return frame_; }
+    etl::span<uint8_t> GetBuffer() { return buffer_; }
+    void SetBuffer(etl::span<uint8_t> buffer) { buffer_ = buffer; }
+
+   private:
+    Frame frame_;
+    etl::span<uint8_t> buffer_;
+};
+
+}  // namespace spiopen

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame_format.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame_format.h
@@ -1,0 +1,94 @@
+/*
+SpIOpen Frame Format : Constants defining the format of a SpIOpen frame. See @FrameFrormat.md for full specification.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace spiopen::format {
+/* Preamble Constants */
+static constexpr uint8_t PREAMBLE_BYTE = 0xAA;             // Value of each byte in the preamble
+static constexpr uint8_t PREAMBLE_BYTE_COMPLEMENT = 0x55;  // Value of the complement of the preamble byte
+static constexpr uint16_t PREAMBLE_WORD = 0xAAAA;          // Value of the preamble word
+
+/* Macros that define byte sizes and offsets for all of the elements of a SpIOpen frame */
+static constexpr size_t PREAMBLE_SIZE = 2;        // Size of the preamble in bytes
+static constexpr size_t FORMAT_HEADER_SIZE = 2;   // Size of the format header in bytes
+static constexpr size_t XL_DATA_LENGTH_SIZE = 2;  // Size of the XL data length field)
+static constexpr size_t XL_CONTROL_SIZE = 6;      // Size of the XL control field in bytes (Less the data length field)
+static constexpr size_t CAN_IDENTIFIER_SIZE = 2;  // Size of the basic CAN identifier in bytes
+static constexpr size_t CAN_IDENTIFIER_EXTENSION_SIZE =
+    2;  // Size of additional extended identifier in bytes (Only used if IDE flag is set)
+static constexpr size_t TIME_TO_LIVE_SIZE =
+    1;  // Size of the Time to Live counter in bytes (Only used if TTL flag is set)
+static constexpr size_t MAX_CC_PAYLOAD_SIZE = 8;   // Maximum payload size in bytes for CAN-CC frames
+static constexpr size_t MAX_FD_PAYLOAD_SIZE = 64;  // Maximum payload size in bytes for CAN-FD frames
+
+static constexpr size_t MAX_XL_PAYLOAD_SIZE = 2048;  // Maximum payload size in bytes for CAN-XL frames
+static constexpr size_t SHORT_CRC_SIZE = 2;          // Size of the CRC16 checksum in bytes (Payloads <= 8 Bytes long)
+static constexpr size_t LONG_CRC_SIZE = 4;           // Size of the CRC32 checksum in bytes (Payloads > 8 Bytes long)
+static constexpr size_t MAX_PADDING_SIZE =
+    1;  // Maximum size of the padding byte in bytes (Only used if WA flag is set)
+
+/* Macros that define the byte masks for the various bit-stuffed flags and sub-integers of the header */
+static constexpr uint8_t HEADER_DLC_MASK = 0x0F;  // Mask for the DLC field in the low byte of the format header
+static constexpr uint8_t HEADER_IDE_MASK = 0x10;  // Mask for the IDE field in the low byte of the format header
+static constexpr uint8_t HEADER_FDF_MASK = 0x20;  // Mask for the FDF field in the low byte of the format header
+static constexpr uint8_t HEADER_XLF_MASK = 0x40;  // Mask for the XLF field in the low byte of the format header
+static constexpr uint8_t HEADER_TTL_MASK = 0x80;  // Mask for the TTL field in the low byte of the format header
+static constexpr uint8_t HEADER_WA_MASK =
+    0x01;  // Mask for the word alignment field in the high byte of the format header
+static constexpr uint8_t CID_RTR_MASK = 0x80;  // Mask for the RTR/RRS field in the highest byte of the CAN identifier
+static constexpr uint8_t CID_BRS_MASK = 0x40;  // Mask for the BRS field in the highest byte of the CAN identifier
+static constexpr uint8_t CID_ESI_MASK = 0x20;  // Mask for the ESI field in the highest byte of the CAN identifier
+
+/* CAN-FD 4-bit DLC to payload length (bytes): 0-8, 12, 16, 20, 24, 32, 48, 64 */
+static constexpr size_t CAN_FD_PAYLOAD_BY_DLC[16] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64};
+
+// Max sizes of relevant data segments of a SpIOpen frame, used to calculate buffer alignment
+static constexpr size_t MAX_CAN_CC_HEADER_SIZE =
+    (PREAMBLE_SIZE + FORMAT_HEADER_SIZE + CAN_IDENTIFIER_SIZE + CAN_IDENTIFIER_EXTENSION_SIZE + TIME_TO_LIVE_SIZE);
+static constexpr size_t MAX_CAN_FD_HEADER_SIZE =
+    (PREAMBLE_SIZE + FORMAT_HEADER_SIZE + CAN_IDENTIFIER_SIZE + CAN_IDENTIFIER_EXTENSION_SIZE + TIME_TO_LIVE_SIZE);
+static constexpr size_t MAX_CAN_XL_HEADER_SIZE =
+    (PREAMBLE_SIZE + FORMAT_HEADER_SIZE + CAN_IDENTIFIER_SIZE + CAN_IDENTIFIER_EXTENSION_SIZE + TIME_TO_LIVE_SIZE +
+     XL_DATA_LENGTH_SIZE + XL_CONTROL_SIZE);
+
+static constexpr size_t MAX_CAN_CC_FRAME_SIZE =
+    (MAX_CAN_CC_HEADER_SIZE + MAX_CC_PAYLOAD_SIZE + SHORT_CRC_SIZE + MAX_PADDING_SIZE);
+static constexpr size_t MAX_CAN_FD_FRAME_SIZE =
+    (MAX_CAN_FD_HEADER_SIZE + MAX_FD_PAYLOAD_SIZE + LONG_CRC_SIZE + MAX_PADDING_SIZE);
+static constexpr size_t MAX_CAN_XL_FRAME_SIZE =
+    (MAX_CAN_XL_HEADER_SIZE + MAX_XL_PAYLOAD_SIZE + LONG_CRC_SIZE + MAX_PADDING_SIZE);
+
+// Convert a 4-bit DLC nibble to the payload length in bytes
+// Only valid for CAN-CC and CAN-FD frames
+static inline size_t GetPayloadLengthFromDlc(const uint8_t dlc_nibble) {
+    return CAN_FD_PAYLOAD_BY_DLC[dlc_nibble & HEADER_DLC_MASK];
+}
+
+// Convert a payload length in bytes to the 4-bit DLC nibble
+// Only valid for CAN-CC and CAN-FD frames
+static inline bool TryGetDlcFromPayloadLength(const size_t payload_length, uint8_t& dlc_out) noexcept {
+    if (payload_length <= MAX_CC_PAYLOAD_SIZE) {
+        dlc_out = static_cast<uint8_t>(payload_length & HEADER_DLC_MASK);
+        return true;
+    }
+    if (payload_length <= MAX_FD_PAYLOAD_SIZE) {
+        for (size_t i = MAX_CC_PAYLOAD_SIZE; i < sizeof(CAN_FD_PAYLOAD_BY_DLC); i++) {
+            if (payload_length <= CAN_FD_PAYLOAD_BY_DLC[i]) {
+                dlc_out = static_cast<uint8_t>(i) & HEADER_DLC_MASK;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static inline size_t GetCrcLengthFromPayloadLength(const size_t payload_length) noexcept {
+    return (payload_length <= MAX_CC_PAYLOAD_SIZE) ? SHORT_CRC_SIZE : LONG_CRC_SIZE;
+}
+}  // namespace spiopen::format

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame_reader.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame_reader.h
@@ -1,0 +1,115 @@
+/*
+SpIOpen Frame Reader : Read and parse SpIOpen frames from byte streams.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/byte_stream.h"
+#include "etl/expected.h"
+#include "etl/span.h"
+#include "spiopen_frame.h"
+#include "spiopen_frame_format.h"
+
+namespace spiopen::frame_reader {
+
+/** Error codes for frame parse/read operations. */
+enum class FrameParseError : uint8_t {
+    NoPreamble = 1,                   // No preamble found at declared frame start position or search limit reached
+    BufferTooShortForPreamble,        // Buffer is too short for the preamble
+    BufferTooShortToDetermineLength,  // Buffer is too short to determine frame length from partial header
+    BufferTooShortForHeader,          // Buffer is too short for the header
+    FormatDlcCorrupted,               // DLC field was corrupted during parsing (due to multiple bit flips)
+    CanFdNotSupported,                // CAN-FD not supported by the frame pool
+    CanXlNotSupported,                // CAN-XL not supported by the frame pool
+    BufferTooShortForPayload,         // Buffer is too short for the payload
+    CrcMismatch,                      // CRC mismatch between calculated and stored CRCs
+    DlcInvalid,                       // DLC field was successfully decoded but indicates an invalid (too large) value
+    InvalidBitSlipCount,              // Bit slip count is invalid (must be between 0 and 7)
+    InvalidPayloadLength,             // Payload length is invalid for the frame type
+    InvalidFrameLength,               // Frame length could not be determined from the parsed header
+};
+
+/** Result of a frame read/parse operation. */
+struct FrameReadResult {
+    bool dlc_corrected;  // True if the DLC field was corrected during parsing (due to single bit flip)
+};
+
+// enum class FrameValidity {
+//     NO_PREAMBLE,          // Unable to find preamble at the cursor position
+//     NO_HEADER_IN_BUFFER,  // Unable to read enough of the header to determine the data length
+//     DLC_RECOVERED,        // DLC field was corrected during parsing (due to single bit flip)
+//     DLC_CORRUPTED,        // DLC field was corrupted during parsing (due to multiple bit flips)
+//     NO_CRC_IN_BUFFER,     // Unable to read enough of the CRC to validate the frame
+//     CRC_MISMATCH,         // CRC mismatch between calculated and stored CRCs
+//     VALID                 // Frame is valid and ready to be used
+// };
+
+// structure that is returned by any function that searches for a SpIOpen frame in a byte array buffer
+struct FrameSearchResult {
+    size_t frame_start_offset;  // Offset of the first byte of the frame (full or partial preamble) from the start of
+                                // the buffer
+    int8_t bit_slip_count;      // Number of bit slips detected during the search for the frame (positive for extra bits
+                                // received, to a maximum of 7. 0 indicates no bit slips)
+    bool valid_preamble_found;  // True if a valid preamble was found
+};
+
+/**
+ * @brief Read a SpIOpen frame from a byte stream. On success, the frame's payload span points into the stream's
+ * buffer.
+ * @param stream Byte stream reader positioned at the start of the frame (preamble). Uses big-endian.
+ * @param out_frame Pointer to the Frame object to store the read frame
+ * @return On success, FrameReadResult with dlc_corrected flag; on failure, the parse error
+ */
+etl::expected<FrameReadResult, FrameParseError> ReadFrame(etl::byte_stream_reader& stream, Frame& out_frame);
+
+/**
+ * @brief Read a SpIOpen frame from an input byte stream, copy it with optional bit-slip correction into a
+ * destination buffer, and parse the result into the frame.
+ * @param input_stream Byte stream reader positioned at the start of the frame (preamble). Uses big-endian.
+ * @param destination_buffer Span of the buffer to receive the copied frame bytes
+ * @param out_frame Pointer to the Frame object to store the read frame (payload will point into destination_buffer)
+ * @param bit_slip_count Number of bit slips to correct for (0 to 7; positive for extra bits received)
+ * @return On success, FrameReadResult with dlc_corrected flag; on failure, the parse error
+ */
+etl::expected<FrameReadResult, FrameParseError> ReadAndCopyFrame(etl::byte_stream_reader& input_stream,
+                                                                 etl::span<uint8_t> destination_buffer,
+                                                                 Frame& out_frame, uint8_t bit_slip_count);
+
+/**
+ * @brief Search for a SpIOpen frame preamble in a buffer.
+ * @param buffer Span of the byte array to search for the preamble in
+ * @param offset Byte offset into the buffer at which to start searching (default 0)
+ * @param bit_slips_allowed If true, allow bit-slip correction and search for complement preamble (default true)
+ * @return FrameSearchResult with frame_start_offset, bit_slip_count, and valid_preamble_found
+ */
+FrameSearchResult FindNextFramePreamble(const etl::span<uint8_t>& buffer, size_t offset = 0,
+                                        bool bit_slips_allowed = true);
+
+/** Helper functions; exposed for testing only. */
+namespace impl {
+etl::expected<void, FrameParseError> ParseFormatHeader(const uint8_t high, const uint8_t low, Frame& frame,
+                                                       bool& dlc_corrected, size_t& payload_len_out);
+etl::expected<void, FrameParseError> ValidatePreamble(etl::byte_stream_reader& stream);
+etl::expected<void, FrameParseError> ReadFormatHeader(etl::byte_stream_reader& stream, Frame& out_frame,
+                                                      bool& dlc_corrected, size_t& payload_len_out);
+etl::expected<void, FrameParseError> ReadXlPayloadLength(etl::byte_stream_reader& stream, Frame& out_frame,
+                                                         bool& dlc_corrected, size_t& payload_len_out);
+etl::expected<void, FrameParseError> ReadXlControl(etl::byte_stream_reader& stream, Frame& out_frame);
+etl::expected<void, FrameParseError> ReadCanID(etl::byte_stream_reader& stream, Frame& out_frame);
+etl::expected<void, FrameParseError> ReadTTL(etl::byte_stream_reader& stream, Frame& out_frame);
+etl::expected<void, FrameParseError> ValidateCRC(etl::byte_stream_reader& stream, const Frame& frame,
+                                                 const etl::span<const uint8_t>& crc_region);
+bool CopyFromBitSlippedBuffer(etl::byte_stream_reader& source, etl::byte_stream_writer& dest, size_t bytes_to_copy,
+                              uint8_t bit_slip_count);
+etl::expected<size_t, FrameParseError> FindNextPreambleByte(const etl::span<uint8_t>& buffer, size_t offset = 0,
+                                                            bool bit_slips_allowed = true);
+etl::expected<uint8_t, FrameParseError> CountBitOffsetIntoPreviousByte(const etl::span<uint8_t>& buffer,
+                                                                       size_t preamble_index = 0);
+}  // namespace impl
+
+}  // namespace spiopen::frame_reader

--- a/Libraries/SpIOpen_Frame/include/spiopen_frame_writer.h
+++ b/Libraries/SpIOpen_Frame/include/spiopen_frame_writer.h
@@ -1,0 +1,52 @@
+/*
+SpIOpen Frame Writer : Used to write a Frame object to a byte array buffer.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/byte_stream.h"
+#include "etl/expected.h"
+#include "spiopen_frame.h"
+#include "spiopen_frame_format.h"
+
+namespace spiopen::frame_writer {
+
+/** Error codes for frame write operations. */
+enum class FrameWriteError : uint8_t {
+    InvalidPayloadLength = 1,  // The data length is invalid for the frame type
+    InvalidFrameLength,        // The frame length is invalid for the frame type
+    InvalidPayloadPointer,     // The payload pointer is invalid or NULL
+    BufferTooShort,            // The buffer is too short to write the frame
+    InvalidBufferPointer,      // The buffer pointer is invalid or NULL
+    InvalidFramePointer,       // The frame pointer is invalid or NULL
+    CanFdNotSupported,         // CAN-FD not supported by the frame pool
+    CanXlNotSupported,         // CAN-XL not supported by the frame pool
+};
+
+/**
+ * @brief Writes a SpIOpen frame to a byte stream writer
+ * @param stream Reference to the byte stream writer to write the frame to
+ * @param frame Reference to the Frame object to write
+ * @return On success, void; on failure, the error code
+ */
+etl::expected<void, FrameWriteError> WriteFrame(etl::byte_stream_writer& stream, const Frame& frame);
+
+// Helper functions for writing a SpIOpen frame to a byte array buffer. Not to be accessed directly.
+namespace impl {
+etl::expected<void, FrameWriteError> ValidateFrame(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WritePreamble(etl::byte_stream_writer& stream);
+etl::expected<void, FrameWriteError> WriteFormatHeader(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WriteCanIdentifier(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WriteXlDataAndControl(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WriteTimeToLive(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WritePayload(etl::byte_stream_writer& stream, const Frame& frame);
+etl::expected<void, FrameWriteError> WriteCrc(etl::byte_stream_writer& stream, const Frame& frame,
+                                              const etl::span<const uint8_t>& crc_region);
+etl::expected<void, FrameWriteError> WriteFramePadding(etl::byte_stream_writer& stream, const Frame& frame);
+}  // namespace impl
+}  // namespace spiopen::frame_writer

--- a/Libraries/SpIOpen_Frame/src/default/spiopen_frame_algorithms.cpp
+++ b/Libraries/SpIOpen_Frame/src/default/spiopen_frame_algorithms.cpp
@@ -1,0 +1,107 @@
+/*
+SpIOpen Frame Algorithm Implementation (Default / Software)
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+
+Default pure-software implementation. Replace this translation unit at link
+time with a platform-specific .cpp for hardware-accelerated CRC/SECDED
+(see AlgorithmBackend.md).
+*/
+
+#include "spiopen_frame_algorithms.h"
+
+#include "etl/crc16_ccitt.h"
+#include "etl/crc32_mpeg2.h"
+#include "etl/span.h"
+
+namespace spiopen::algorithms {
+
+uint16_t ComputeCrc16(const etl::span<const uint8_t>& data) {
+    etl::crc16_ccitt crc;
+    crc.add(data.begin(), data.end());
+    return static_cast<uint16_t>(crc.value());
+}
+
+uint32_t ComputeCrc32(const etl::span<const uint8_t>& data) {
+    etl::crc32_mpeg2 crc;
+    crc.add(data.begin(), data.end());
+    return crc.value();
+}
+
+// #TODO: use more etl::binary functionality to repalce a lot of these bitwise operations
+
+// use constants to trade memory for speed:
+static constexpr uint16_t secded16_num_data_bits = 11U;
+static constexpr uint16_t secded16_num_parity_bits = 5U;
+static constexpr uint16_t secded16_data_bit_mask = static_cast<uint16_t>(0xFFFFU) >> secded16_num_parity_bits;
+static constexpr std::array<uint16_t, 5> secded16_partiy_data_masks = {
+    0b0000'0101'0101'1011,   // hamming parity bit 0, encoding bits [0,1,3,4,6,8,10]
+    0b0000'0110'0110'1101,   // hamming parity bit 1, encoding bits [0,2,3,5,6,9,10]
+    0b0000'0111'1000'1110,   // hamming parity bit 2, encoding bits [1,2,3,7,8,9,10]
+    0b0000'0111'1111'0000,   // hamming parity bit 3, encoding bits [4,5,6,7,8,9,10]
+    0b0111'1111'1111'1111};  // overall parity encoding all data bits and parity bits
+static constexpr std::array<uint16_t, 5> secded16_parity_bit_position_masks = {
+    1U << (secded16_num_data_bits + 0U), 1U << (secded16_num_data_bits + 1U), 1U << (secded16_num_data_bits + 2U),
+    1U << (secded16_num_data_bits + 3U), 1U << (secded16_num_data_bits + 4U)};
+static constexpr uint16_t secded16_syndrome_mask =
+    secded16_parity_bit_position_masks[0] | secded16_parity_bit_position_masks[1] |
+    secded16_parity_bit_position_masks[2] | secded16_parity_bit_position_masks[3];
+static constexpr uint16_t secded16_overall_parity_mask = secded16_parity_bit_position_masks[4];
+static constexpr uint8_t secded16_syndrome_to_data_bit_mapping[secded16_num_data_bits + secded16_num_parity_bits] = {
+    11U, 12U, 0U, 13U, 1U, 2U, 3U, 14U, 4U, 5U, 6U, 7U, 8U, 9U, 10U};  // 0-based indices
+
+// SECDED(16,11) systematic encoding
+// The data bits are placed in the least significant positions
+// in the encoded word. Hamming parity bits are palced at bit positions 12-15, and the overall parity bit is placed at
+// bit position 16. Bit number 1 is the least significant.
+uint16_t Secded16Encode11(const uint16_t raw11) {
+    uint16_t code = raw11 & secded16_data_bit_mask;
+    for (uint8_t parity_bit_index = 0U; parity_bit_index < secded16_num_parity_bits; ++parity_bit_index) {
+        if (__builtin_popcount(code & secded16_partiy_data_masks[parity_bit_index]) &
+            1U) {  // TRUE if odd number of bits in the group are true
+            code |= secded16_parity_bit_position_masks[parity_bit_index];  // set the parity bit to 1 to ensure even
+                                                                           // parity in the group
+        }
+    }
+    return code;
+}
+
+// SECDED(16,11) systematic decoding
+// The data bits are placed in the least significant positions
+// in the encoded word. Hamming parity bits are palced at bit positions 12-15, and the overall parity bit is placed at
+// bit position 16. Bit number 1 is the least significant.
+Secded16DecodeResult Secded16Decode11(uint16_t encoded16) {
+    Secded16DecodeResult result{};
+    result.data11 = encoded16 & secded16_data_bit_mask;
+    result.corrected = false;
+    result.uncorrectable = false;
+    uint16_t reencoded16 = Secded16Encode11(result.data11);
+    if (encoded16 == reencoded16) {
+        return result;
+    }
+
+    if (__builtin_popcount(encoded16) % 2U !=
+        0) {  // overall parity is incorrect so there must be an odd number of errors
+        // Assume there is exactly one error and correct it using the syndrome.
+        uint16_t syndrome = (encoded16 ^ reencoded16) & secded16_syndrome_mask;
+        if (syndrome != 0U) {  // syndrome is non-zero, so we have a single-bit error in the data or syndrome bits
+            syndrome >>=
+                secded16_num_data_bits;  // syndrome now points to the 1-based data bit in the interleaved
+                                         // secded method which needs to be corrected. Use a lookup table to account for
+                                         // the difference between bit positions in the interleaved method (easy
+                                         // correciton math) and the systematic method (used on the wire)
+            size_t error_bit_position = secded16_syndrome_to_data_bit_mapping[syndrome - 1U];  // 0 based index
+            result.corrected = true;
+            result.data11 = (encoded16 ^ (1U << error_bit_position)) & secded16_data_bit_mask;
+        } else {  // syndrome is zero, so the overall parity is the only error. Don't bother correcting it because we
+                  // don't even return it.
+            result.corrected = true;
+        }
+    } else {  // overall parity is correct but the syndrome doesn't match, so there must be an even number of errors
+        result.uncorrectable = true;  // even numbers of errors, even two, are not correctable
+    }
+
+    return result;
+}
+}  // namespace spiopen::algorithms

--- a/Libraries/SpIOpen_Frame/src/spiopen_frame_reader.cpp
+++ b/Libraries/SpIOpen_Frame/src/spiopen_frame_reader.cpp
@@ -1,0 +1,551 @@
+/*
+SpIOpen Frame Reader : Implementation
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "spiopen_frame_reader.h"
+
+#include <etl/byte_stream.h>
+#include <etl/expected.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "spiopen_frame_algorithms.h"
+
+namespace spiopen::frame_reader {
+
+using namespace spiopen::format;
+
+namespace impl {
+
+etl::expected<void, FrameParseError> ParseFormatHeader(const uint8_t high, const uint8_t low, Frame& frame,
+                                                       bool& dlc_corrected, size_t& payload_len_out) {
+    const uint16_t encoded_header = static_cast<uint16_t>((static_cast<uint16_t>(high) << 8U) | low);
+    const algorithms::Secded16DecodeResult decoded = algorithms::Secded16Decode11(encoded_header);
+    if (decoded.uncorrectable) {
+        return etl::unexpected(FrameParseError::FormatDlcCorrupted);
+    }
+    dlc_corrected = dlc_corrected || decoded.corrected;
+
+    const uint16_t raw_header11 = decoded.data11;
+    const uint8_t dlc_nibble = static_cast<uint8_t>(raw_header11 & HEADER_DLC_MASK);
+    frame.can_flags.IDE = (raw_header11 & static_cast<uint16_t>(HEADER_IDE_MASK)) != 0U;
+    frame.can_flags.FDF = (raw_header11 & static_cast<uint16_t>(HEADER_FDF_MASK)) != 0U;
+    frame.can_flags.XLF = (raw_header11 & static_cast<uint16_t>(HEADER_XLF_MASK)) != 0U;
+    frame.can_flags.TTL = (raw_header11 & static_cast<uint16_t>(HEADER_TTL_MASK)) != 0U;
+    frame.can_flags.WA = ((raw_header11 >> 8U) & HEADER_WA_MASK) != 0U;
+
+    payload_len_out = GetPayloadLengthFromDlc(dlc_nibble);
+    return {};
+}
+
+etl::expected<void, FrameParseError> ValidatePreamble(etl::byte_stream_reader& stream) {
+    auto b0 = stream.read<uint8_t>();
+    if (!b0) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPreamble);
+    }
+    auto b1 = stream.read<uint8_t>();
+    if (!b1) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPreamble);
+    }
+    if (*b0 != PREAMBLE_BYTE || *b1 != PREAMBLE_BYTE) {
+        return etl::unexpected(FrameParseError::NoPreamble);
+    }
+    return {};
+}
+
+etl::expected<void, FrameParseError> ReadFormatHeader(etl::byte_stream_reader& stream, Frame& out_frame,
+                                                      bool& dlc_corrected, size_t& payload_len_out) {
+    auto hw = stream.read<uint16_t>();
+    if (!hw) {
+        return etl::unexpected(FrameParseError::BufferTooShortToDetermineLength);
+    }
+    const uint8_t low = static_cast<uint8_t>(*hw & 0xFFU);
+    const uint8_t high = static_cast<uint8_t>(*hw >> 8U);
+
+    auto parse_result = ParseFormatHeader(high, low, out_frame, dlc_corrected, payload_len_out);
+    if (!parse_result) {
+        return parse_result;
+    }
+
+#ifndef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    if (out_frame.can_flags.FDF) {
+        return etl::unexpected(FrameParseError::CanFdNotSupported);
+    }
+#endif
+#ifndef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    if (out_frame.can_flags.XLF) {
+        return etl::unexpected(FrameParseError::CanXlNotSupported);
+    }
+#endif
+    return {};
+}
+
+etl::expected<void, FrameParseError> ReadXlPayloadLength(etl::byte_stream_reader& stream, Frame& out_frame,
+                                                         bool& dlc_corrected, size_t& payload_len_out) {
+    auto enc = stream.read<uint16_t>();
+    if (!enc) {
+        return etl::unexpected(FrameParseError::BufferTooShortToDetermineLength);
+    }
+    const algorithms::Secded16DecodeResult decoded = algorithms::Secded16Decode11(*enc);
+    if (decoded.uncorrectable) {
+        return etl::unexpected(FrameParseError::FormatDlcCorrupted);
+    }
+    dlc_corrected = dlc_corrected || decoded.corrected;
+
+    payload_len_out = static_cast<size_t>(decoded.data11);
+    if (payload_len_out > MAX_XL_PAYLOAD_SIZE) {
+        return etl::unexpected(FrameParseError::DlcInvalid);
+    }
+    return {};
+}
+
+etl::expected<void, FrameParseError> ReadXlControl(etl::byte_stream_reader& stream, Frame& out_frame) {
+    auto pt = stream.read<uint8_t>();
+    if (!pt) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    out_frame.xl_control.payload_type = *pt;
+
+    auto vcid = stream.read<uint8_t>();
+    if (!vcid) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    out_frame.xl_control.virtual_can_network_id = *vcid;
+
+    auto addr = stream.read<uint32_t>();
+    if (!addr) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    out_frame.xl_control.addressing_field = *addr;
+    return {};
+}
+
+etl::expected<void, FrameParseError> ReadCanID(etl::byte_stream_reader& stream, Frame& out_frame) {
+    auto cid_b0 = stream.read<uint8_t>();
+    if (!cid_b0) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    auto cid_b1 = stream.read<uint8_t>();
+    if (!cid_b1) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    out_frame.can_flags.RTR = (*cid_b0 & CID_RTR_MASK) != 0U;
+    out_frame.can_flags.BRS = (*cid_b0 & CID_BRS_MASK) != 0U;
+    out_frame.can_flags.ESI = (*cid_b0 & CID_ESI_MASK) != 0U;
+
+    const uint8_t b0 = *cid_b0 & static_cast<uint8_t>(~(CID_RTR_MASK | CID_BRS_MASK | CID_ESI_MASK));
+    if (out_frame.can_flags.IDE) {
+        auto cid_b2 = stream.read<uint8_t>();
+        if (!cid_b2) {
+            return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+        }
+        auto cid_b3 = stream.read<uint8_t>();
+        if (!cid_b3) {
+            return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+        }
+        out_frame.can_identifier = (static_cast<uint32_t>(b0) << 24U) | (static_cast<uint32_t>(*cid_b1) << 16U) |
+                                   (static_cast<uint32_t>(*cid_b2) << 8U) | static_cast<uint32_t>(*cid_b3);
+    } else {
+        out_frame.can_identifier = (static_cast<uint32_t>(b0) << 8U) | static_cast<uint32_t>(*cid_b1);
+    }
+    return {};
+}
+
+etl::expected<void, FrameParseError> ReadTTL(etl::byte_stream_reader& stream, Frame& out_frame) {
+    auto ttl = stream.read<uint8_t>();
+    if (!ttl) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    out_frame.time_to_live = *ttl;
+    return {};
+}
+
+etl::expected<void, FrameParseError> ValidateCRC(etl::byte_stream_reader& stream, const Frame& frame,
+                                                 const etl::span<const uint8_t>& crc_region) {
+    size_t payload_length;
+    if (!frame.TryGetPayloadSectionLength(payload_length)) {
+        return etl::unexpected(FrameParseError::InvalidPayloadLength);
+    }
+    const size_t crc_size = GetCrcLengthFromPayloadLength(payload_length);
+    if (crc_size == SHORT_CRC_SIZE) {
+        auto received = stream.read<uint16_t>();
+        if (!received) {
+            return etl::unexpected(FrameParseError::BufferTooShortForPayload);
+        }
+        const uint16_t computed_crc = algorithms::ComputeCrc16(crc_region);
+        if (computed_crc != *received) {
+            return etl::unexpected(FrameParseError::CrcMismatch);
+        }
+    } else {
+        auto received = stream.read<uint32_t>();
+        if (!received) {
+            return etl::unexpected(FrameParseError::BufferTooShortForPayload);
+        }
+        const uint32_t computed_crc = algorithms::ComputeCrc32(crc_region);
+        if (computed_crc != *received) {
+            return etl::unexpected(FrameParseError::CrcMismatch);
+        }
+    }
+    return {};
+}
+
+//#TODO: use the ETL::bi_stream_X functions to make this more clear, and maybe more efficient
+//@param bit_slip_count: positive for extra bits received (effectively a right shift of the data), to a maximum of 7. 0
+// indicates no bit slips
+// return true if the copy was successful, false otherwise.
+// Dont use FrameParseError because the caller of this funciton can encoder more context on the failure (preamble,
+// header, payload, crc, etc)
+bool CopyFromBitSlippedBuffer(etl::byte_stream_reader& source, etl::byte_stream_writer& dest, size_t bytes_to_copy,
+                              uint8_t bit_slip_count) {
+    if (bit_slip_count > 7U) {
+        return false;
+    }
+    if (dest.available_bytes() < bytes_to_copy) {
+        return false;
+    }
+    if (bit_slip_count == 0U) {  // For byte aligned frames, we can just copy the data
+        if (source.available_bytes() < bytes_to_copy) {
+            return false;
+        }
+        std::memcpy(dest.free_data().data(), source.free_data().data(), bytes_to_copy);
+        source.skip<uint8_t>(bytes_to_copy);
+        dest.skip<uint8_t>(bytes_to_copy);
+        return true;
+    }
+    // we need one extra byte from the source when compensating for bit slip
+    if (source.available_bytes() <= bytes_to_copy) {
+        return false;
+    }
+    uint8_t high = source.read_unchecked<uint8_t>();  // this is the "extra" byte that we read
+    for (size_t i = 0U; i < bytes_to_copy; ++i) {
+        uint8_t low = source.read_unchecked<uint8_t>();
+        // correct for the effective right shift by left shifting the high byte back into alignment.
+        // Then right shift the low byte by the opposite amount so we can OR the two together to get the final byte.
+        const uint8_t out =
+            static_cast<uint8_t>((static_cast<uint16_t>(high) << bit_slip_count) | (low >> (8U - bit_slip_count)));
+        dest.write_unchecked(out);
+        high = low;
+    }
+    source.restart(source.used_data().size() - 1U);  // move back one byte so a subsequent call can read a partial byte.
+    return true;
+}
+
+}  // namespace impl
+
+using namespace impl;
+
+etl::expected<FrameReadResult, FrameParseError> ReadFrame(etl::byte_stream_reader& stream, Frame& out_frame) {
+    FrameReadResult result{};
+    result.dlc_corrected = false;
+
+    out_frame.Reset();
+
+    auto v = ValidatePreamble(stream);
+    if (!v) {
+        return etl::unexpected(v.error());
+    }
+
+    size_t start_position = stream.used_data().size();
+
+    size_t payload_len = 0U;  // when reading from the wire, there is never any payload padding.
+    auto hdr = ReadFormatHeader(stream, out_frame, result.dlc_corrected, payload_len);
+    if (!hdr) {
+        return etl::unexpected(hdr.error());
+    }
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    if (out_frame.can_flags.XLF) {
+        auto xl_len = ReadXlPayloadLength(stream, out_frame, result.dlc_corrected, payload_len);
+        if (!xl_len) {
+            return etl::unexpected(xl_len.error());
+        }
+
+        auto xl_ctrl = ReadXlControl(stream, out_frame);
+        if (!xl_ctrl) {
+            return etl::unexpected(xl_ctrl.error());
+        }
+    }
+#endif
+
+    auto cid = ReadCanID(stream, out_frame);
+    if (!cid) {
+        return etl::unexpected(cid.error());
+    }
+
+    if (out_frame.can_flags.TTL) {
+        auto ttl = ReadTTL(stream, out_frame);
+        if (!ttl) {
+            return etl::unexpected(ttl.error());
+        }
+    }
+
+    auto payload_data = stream.read<uint8_t>(payload_len);
+    if (!payload_data) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPayload);
+    }
+    // it comes out of the reader as a const span, so we need to cast it to a mutable span
+    out_frame.payload = etl::span<uint8_t>(const_cast<uint8_t*>((*payload_data).data()), (*payload_data).size());
+
+    auto crc_region = stream.used_data().subspan(start_position);  // start position is marked after preamble
+    auto crc =
+        ValidateCRC(stream, out_frame,
+                    etl::span<const uint8_t>(reinterpret_cast<const uint8_t*>(crc_region.data()), crc_region.size()));
+    if (!crc) {
+        return etl::unexpected(crc.error());
+    }
+
+    return result;
+}
+
+etl::expected<FrameReadResult, FrameParseError> ReadAndCopyFrame(etl::byte_stream_reader& input_stream,
+                                                                 etl::span<uint8_t> destination_buffer,
+                                                                 Frame& out_frame, uint8_t bit_slip_count) {
+    FrameReadResult result{};
+    result.dlc_corrected = false;
+
+    out_frame.Reset();
+
+    etl::byte_stream_writer destination_stream_writer(destination_buffer,
+                                                      etl::endian::big);  // used for transfer
+    etl::byte_stream_reader destination_stream_reader(destination_buffer.data(), destination_buffer.size(),
+                                                      etl::endian::big);  // used for parsing
+
+    etl::expected<void, FrameParseError> frame_parse_result;
+
+    // preamble - check it so we can exit early if this isnt even a frame
+    if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, PREAMBLE_SIZE, bit_slip_count)) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPreamble);
+    }
+    frame_parse_result = ValidatePreamble(destination_stream_reader);
+    if (!frame_parse_result) {
+        return etl::unexpected(frame_parse_result.error());
+    }
+
+    // format header - after this we should know the full length of everything unless its a CAN-XL frame
+    if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, FORMAT_HEADER_SIZE, bit_slip_count)) {
+        return etl::unexpected(FrameParseError::BufferTooShortToDetermineLength);
+    }
+    size_t payload_len = 0U;  // this will hold the length of the payload in the wire, including payloa dpadding, but
+                              // excluding frame padding.
+    frame_parse_result = ReadFormatHeader(destination_stream_reader, out_frame, result.dlc_corrected, payload_len);
+    if (!frame_parse_result) {
+        return etl::unexpected(frame_parse_result.error());
+    }
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    if (out_frame.can_flags.XLF) {
+        // xl data length - we def know the total length after this
+        if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, XL_DATA_LENGTH_SIZE, bit_slip_count)) {
+            return etl::unexpected(FrameParseError::BufferTooShortToDetermineLength);
+        }
+        frame_parse_result =
+            ReadXlPayloadLength(destination_stream_reader, out_frame, result.dlc_corrected, payload_len);
+        if (!frame_parse_result) {
+            return etl::unexpected(frame_parse_result.error());
+        }
+
+        // xl control
+        if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, XL_CONTROL_SIZE, bit_slip_count)) {
+            return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+        }
+        frame_parse_result = ReadXlControl(destination_stream_reader, out_frame);
+        if (!frame_parse_result) {
+            return etl::unexpected(frame_parse_result.error());
+        }
+    }
+#endif
+
+    // can id
+    const size_t can_id_size = out_frame.GetCanIdLength();
+    if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, can_id_size, bit_slip_count)) {
+        return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+    }
+    frame_parse_result = ReadCanID(destination_stream_reader, out_frame);
+    if (!frame_parse_result) {
+        return etl::unexpected(frame_parse_result.error());
+    }
+
+    // ttl
+    if (out_frame.can_flags.TTL) {
+        if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, TIME_TO_LIVE_SIZE, bit_slip_count)) {
+            return etl::unexpected(FrameParseError::BufferTooShortForHeader);
+        }
+        frame_parse_result = ReadTTL(destination_stream_reader, out_frame);
+        if (!frame_parse_result) {
+            return etl::unexpected(frame_parse_result.error());
+        }
+    }
+
+    // payload
+    auto payload_data = destination_stream_reader.free_data().subspan(0, payload_len);
+    // will only become valid after the next copy, but it helps us to calculate how much to copy to finish off the
+    // frame. We have to recast it to make it writable, even though the underlying buffer is writable.
+    out_frame.payload =
+        etl::span<uint8_t>(reinterpret_cast<uint8_t*>(const_cast<char*>(payload_data.data())), payload_data.size());
+    size_t frame_length;
+    if (!out_frame.TryGetFrameLength(frame_length)) {
+        return etl::unexpected(FrameParseError::InvalidFrameLength);
+    }
+    size_t remaining_bytes = frame_length - (PREAMBLE_SIZE + out_frame.GetHeaderLength());
+    // copy the rest of the frame
+    if (!CopyFromBitSlippedBuffer(input_stream, destination_stream_writer, remaining_bytes, bit_slip_count)) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPayload);
+    }
+    destination_stream_reader.restart(frame_length -
+                                      GetCrcLengthFromPayloadLength(payload_len));  // set up to read the crc
+    auto crc_region = destination_stream_reader.used_data().subspan(PREAMBLE_SIZE);
+
+    frame_parse_result =
+        ValidateCRC(destination_stream_reader, out_frame,
+                    etl::span<const uint8_t>(reinterpret_cast<const uint8_t*>(crc_region.data()), crc_region.size()));
+    if (!frame_parse_result) {
+        return etl::unexpected(frame_parse_result.error());
+    }
+
+    return result;
+}
+
+namespace impl {
+
+/**
+ * @brief Search for a SpIOpen frame preamble in a byte array buffer
+ * @param buffer Pointer to the byte array buffer to find the preamble in
+ * @param offset Offset of the first byte of the frame from the start of the buffer
+ * @param bit_slips_allowed True if bit slips are allowed during the search for the preamble (search for complement
+ * preamble)
+ * @return Offset from the beginning of the buffer of the first byte in the buffer that matches the preamble or its
+ * complement, or a frame parse error code if an error occurred or no one-byte preamble was found.
+ */
+etl::expected<size_t, FrameParseError> FindNextPreambleByte(const etl::span<uint8_t>& buffer, size_t offset,
+                                                            bool bit_slips_allowed) {
+    if (offset >= buffer.size()) {
+        return etl::unexpected(FrameParseError::BufferTooShortForPreamble);
+    }
+    const void* standard_preamble_index = memchr(buffer.data() + offset, PREAMBLE_BYTE, buffer.size() - offset);
+    if (!bit_slips_allowed) {
+        if (standard_preamble_index == nullptr) {
+            return etl::unexpected(FrameParseError::NoPreamble);
+        }
+        return static_cast<size_t>(static_cast<const uint8_t*>(standard_preamble_index) - buffer.data());
+    }
+
+    // case where bit slips are allowed and we can also search for the complement preamble
+    const void* complement_preamble_index =
+        memchr(buffer.data() + offset, PREAMBLE_BYTE_COMPLEMENT, buffer.size() - offset);
+    if (standard_preamble_index == nullptr && complement_preamble_index == nullptr) {
+        return etl::unexpected(FrameParseError::NoPreamble);
+    }
+    if (standard_preamble_index == nullptr) {
+        return static_cast<size_t>(static_cast<const uint8_t*>(complement_preamble_index) - buffer.data());
+    }
+    if (complement_preamble_index == nullptr) {
+        return static_cast<size_t>(static_cast<const uint8_t*>(standard_preamble_index) - buffer.data());
+    }
+    return static_cast<size_t>(std::min(static_cast<const uint8_t*>(standard_preamble_index) - buffer.data(),
+                                        static_cast<const uint8_t*>(complement_preamble_index) - buffer.data()));
+}
+
+/**
+ * @brief Determine the number of bit slips that result in the earliest occurrence of the preamble in a byte array
+ * buffer.
+ * @param buffer Span of the byte array buffer
+ * @param preamble_index Offset of the first byte identified as being either the preamble or its complement
+ * @return The number of bits into the preceding byte that should be considered part of the preamble. Positive for each
+ * bit into the preceding byte that should be considered part of the preamble, to a maximum of 7. 0 indicates no bit
+ * slips. A frame parse error code if an error occurred or no full 2-byte preamble was found..
+ */
+etl::expected<uint8_t, FrameParseError> CountBitOffsetIntoPreviousByte(const etl::span<uint8_t>& buffer,
+                                                                       size_t preamble_index) {
+    if (preamble_index + 1U >= buffer.size()) {  // we will always need to search the next byte
+        return etl::unexpected(FrameParseError::BufferTooShortForPreamble);
+    }
+
+    uint8_t index_byte = buffer[preamble_index];
+    uint8_t next_byte = buffer[preamble_index + 1U];
+
+    // The only way to return a success if the preambel_index is the first byte in the buffer is if the preamble is
+    // perfectly aligned with our buffer (probably the most common case anyway)
+    if (preamble_index == 0U) {
+        if ((index_byte == PREAMBLE_BYTE) && (next_byte == PREAMBLE_BYTE)) {
+            return 0U;  // no bit offsets
+        }
+        return etl::unexpected(FrameParseError::NoPreamble);  // searching algorithm will likely advance the cursor and
+                                                              // inspect the next byte, with lookback to this first byte
+    }
+    // now we know that the previous byte is safe to read. The only question is, how many bits into the previous byte
+    // does the preamble pattern extend?
+    uint8_t previous_byte_pattern_match = ~(
+        buffer[preamble_index - 1U] ^ index_byte);  // remember that the index byte has either the preamble data or its
+                                                    // complement, but that pattern should match across byte boundaries
+
+    // bit slip will be either odd or even depending on whether the idnex has a true preamble or complement
+    uint8_t out_bit_offset = 6U;  // case where the true preamble is in the index position
+    if (index_byte == PREAMBLE_BYTE_COMPLEMENT) {
+        if ((previous_byte_pattern_match & 1U) == 0U) {
+            return etl::unexpected(FrameParseError::NoPreamble);  // likely 7 bits of slip on the *next* buffer index
+        }
+        out_bit_offset =
+            7U;  // now we know that we see a matching true preamble (not complement) one bit higher.
+                 // So we can search just for the true preamble on odd slips (default is true preamble on even slips).
+    }
+    uint8_t next_byte_pattern_match = ~(next_byte ^ index_byte);
+    uint8_t pattern_mask =
+        (0xFFU) >> (8U - out_bit_offset);  // describes the bits of the previous byte that are part of the preamble
+                                           // pattern. Will shift them out as we search for smaller and smaller shifts
+    while (out_bit_offset > 1U) {  // we already know that bit_slip of 1 is a match if we are searching for odd slips,
+        // but its our worst possible odd match.
+        uint8_t pattern_mask_complement = (~pattern_mask);
+        bool previous_byte_matches = (previous_byte_pattern_match & pattern_mask);
+        bool next_byte_matches = (next_byte_pattern_match & pattern_mask_complement);
+        if (((previous_byte_pattern_match & pattern_mask) == pattern_mask) &&
+            ((next_byte_pattern_match & pattern_mask_complement) == pattern_mask_complement)) {
+            return out_bit_offset;
+        }
+        out_bit_offset -= 2U;
+        pattern_mask >>= 2U;
+    }
+    return out_bit_offset;
+}
+
+}  // namespace impl
+
+FrameSearchResult FindNextFramePreamble(const etl::span<uint8_t>& buffer, size_t offset, bool bit_slips_allowed) {
+    FrameSearchResult result{};
+    result.valid_preamble_found = false;
+    result.frame_start_offset = offset;  // use this as a working counter for candidate 2-byte preambles
+
+    while (!result.valid_preamble_found) {
+        auto preamble_index = FindNextPreambleByte(buffer, result.frame_start_offset, bit_slips_allowed);
+        if (!preamble_index) {
+            return result;  // give up, no preambles found in the rest of the buffer
+        }
+        if (bit_slips_allowed) {
+            auto bit_result = CountBitOffsetIntoPreviousByte(buffer, *preamble_index);
+            if (bit_result) {
+                result.valid_preamble_found = true;
+                result.bit_slip_count = static_cast<int8_t>(8U - *bit_result);
+                result.frame_start_offset = *bit_result > 0 ? *preamble_index - 1u : *preamble_index;
+                return result;
+            }
+        } else {
+            if (*preamble_index + 1U < buffer.size() && buffer[*preamble_index + 1U] == PREAMBLE_BYTE) {
+                result.valid_preamble_found = true;
+                result.bit_slip_count = 0U;
+                result.frame_start_offset = *preamble_index;
+                return result;
+            }
+        }
+        // no 2-byte preamble found. increment the search pointer and try again
+        result.frame_start_offset = *preamble_index + 1u;
+        continue;
+    }
+    return result;  // should never get here
+}
+
+}  // namespace spiopen::frame_reader

--- a/Libraries/SpIOpen_Frame/src/spiopen_frame_writer.cpp
+++ b/Libraries/SpIOpen_Frame/src/spiopen_frame_writer.cpp
@@ -1,0 +1,268 @@
+/*
+SpIOpen Frame Writer : Implementation
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+
+#include "spiopen_frame_writer.h"
+
+#include <etl/byte_stream.h>
+#include <etl/expected.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "spiopen_frame_algorithms.h"
+#include "spiopen_frame_format.h"
+
+namespace spiopen::frame_writer {
+
+using namespace spiopen::format;
+
+namespace impl {
+
+// Checks that the frame is internally valid (data length, etc) and that the buffer can hold the frame.
+etl::expected<void, FrameWriteError> ValidateFrame(etl::byte_stream_writer& stream, const Frame& frame) {
+    size_t payload_len;
+    if (!frame.TryGetPayloadSectionLength(payload_len)) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+    size_t frame_len;
+    if (!frame.TryGetFrameLength(frame_len)) {
+        return etl::unexpected(FrameWriteError::InvalidFrameLength);
+    }
+    if (stream.available_bytes() < frame_len) {
+        return etl::unexpected(FrameWriteError::BufferTooShort);
+    }
+
+    const bool fdf = frame.can_flags.FDF;
+    const bool xlf = frame.can_flags.XLF;
+    if (!xlf && !fdf && payload_len > MAX_CC_PAYLOAD_SIZE) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    if (!xlf && fdf && payload_len > MAX_FD_PAYLOAD_SIZE) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+#else
+    if (fdf) {
+        return etl::unexpected(FrameWriteError::CanFdNotSupported);
+    }
+#endif
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    if (xlf && payload_len > MAX_XL_PAYLOAD_SIZE) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+#else
+    if (xlf) {
+        return etl::unexpected(FrameWriteError::CanXlNotSupported);
+    }
+#endif
+
+    return {};
+}
+
+/**
+ * @brief Write the preamble bytes to the stream (big-endian word 0xAAAA).
+ */
+etl::expected<void, FrameWriteError> WritePreamble(etl::byte_stream_writer& stream) {
+    return stream.write(static_cast<uint16_t>(PREAMBLE_WORD)) ? etl::expected<void, FrameWriteError>()
+                                                              : etl::unexpected(FrameWriteError::BufferTooShort);
+}
+
+/**
+ * @brief Write the encoded format header (11-bit SECDED) to the stream as big-endian uint16_t.
+ */
+etl::expected<void, FrameWriteError> WriteFormatHeader(etl::byte_stream_writer& stream, const Frame& frame) {
+    uint8_t dlc_low_nibble = 0;
+    if (!TryGetDlcFromPayloadLength(frame.payload.size(), dlc_low_nibble)) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+    const uint8_t low = static_cast<uint8_t>(
+        (dlc_low_nibble & HEADER_DLC_MASK) | (frame.can_flags.IDE ? HEADER_IDE_MASK : 0U) |
+        (frame.can_flags.FDF ? HEADER_FDF_MASK : 0U) | (frame.can_flags.XLF ? HEADER_XLF_MASK : 0U) |
+        (frame.can_flags.TTL ? HEADER_TTL_MASK : 0U));
+    const uint8_t high = frame.can_flags.WA ? HEADER_WA_MASK : 0U;
+
+    const uint16_t raw_header11 =
+        static_cast<uint16_t>(low) | static_cast<uint16_t>((static_cast<uint16_t>(high & HEADER_WA_MASK)) << 8U);
+    const uint16_t encoded_header = algorithms::Secded16Encode11(raw_header11);
+
+    return stream.write(encoded_header) ? etl::expected<void, FrameWriteError>()
+                                        : etl::unexpected(FrameWriteError::BufferTooShort);
+}
+
+/**
+ * @brief Write the CAN identifier (standard or extended) and flag bits to the stream (big-endian).
+ */
+etl::expected<void, FrameWriteError> WriteCanIdentifier(etl::byte_stream_writer& stream, const Frame& frame) {
+    const size_t cid_size = frame.GetCanIdLength();
+    uint32_t id32 = frame.can_identifier;
+    const uint8_t high_byte_flags = (frame.can_flags.RTR ? CID_RTR_MASK : 0U) |
+                                    (frame.can_flags.BRS ? CID_BRS_MASK : 0U) |
+                                    (frame.can_flags.ESI ? CID_ESI_MASK : 0U);
+
+    if (frame.can_flags.IDE) {
+        id32 |= static_cast<uint32_t>(high_byte_flags) << 24U;
+        return stream.write(id32) ? etl::expected<void, FrameWriteError>()
+                                  : etl::unexpected(FrameWriteError::BufferTooShort);
+    } else {
+        const uint16_t id16 = static_cast<uint16_t>(id32) | (static_cast<uint16_t>(high_byte_flags) << 8U);
+        return stream.write(id16) ? etl::expected<void, FrameWriteError>()
+                                  : etl::unexpected(FrameWriteError::BufferTooShort);
+    }
+}
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+/**
+ * @brief Write the XL data length (SECDED) and control field to the stream (big-endian multi-byte values).
+ */
+etl::expected<void, FrameWriteError> WriteXlDataAndControl(etl::byte_stream_writer& stream, const Frame& frame) {
+    const uint16_t encoded_xl_dlc = algorithms::Secded16Encode11(static_cast<uint16_t>(frame.payload.size() & 0x07FFU));
+    bool wrote_all = true;
+    // short circuit evaluation to write all the bytes
+    return (stream.write(encoded_xl_dlc) && stream.write(frame.xl_control.payload_type) &&
+            stream.write(frame.xl_control.virtual_can_network_id) && stream.write(frame.xl_control.addressing_field))
+               ? etl::expected<void, FrameWriteError>()
+               : etl::unexpected(FrameWriteError::BufferTooShort);
+}
+#endif
+
+/**
+ * @brief Write the Time-To-Live byte to the stream if the TTL flag is set.
+ */
+etl::expected<void, FrameWriteError> WriteTimeToLive(etl::byte_stream_writer& stream, const Frame& frame) {
+    if (!frame.can_flags.TTL) {
+        return {};
+    }
+    return stream.write(frame.time_to_live) ? etl::expected<void, FrameWriteError>()
+                                            : etl::unexpected(FrameWriteError::BufferTooShort);
+}
+
+/**
+ * @brief Write the payload bytes and any required DLC padding to the stream.
+ */
+etl::expected<void, FrameWriteError> WritePayload(etl::byte_stream_writer& stream, const Frame& frame) {
+    const etl::span<uint8_t> payload = frame.payload;
+    size_t section_length;
+    if (!frame.TryGetPayloadSectionLength(section_length)) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+
+    if (payload.size() > 0U) {
+        if (!stream.write(payload)) {
+            return etl::unexpected(FrameWriteError::BufferTooShort);
+        }
+    }
+    for (size_t i = payload.size(); i < section_length; ++i) {
+        if (!stream.write(static_cast<uint8_t>(0U))) {
+            return etl::unexpected(FrameWriteError::BufferTooShort);
+        }
+    }
+    return {};
+}
+
+/**
+ * @brief Write word-alignment padding byte to the stream if WA flag is set and current length is odd.
+ */
+etl::expected<void, FrameWriteError> WriteFramePadding(etl::byte_stream_writer& stream, const Frame& frame) {
+    if (!frame.can_flags.WA) {
+        return {};
+    }
+    const size_t current_length = stream.size_bytes() - PREAMBLE_SIZE;
+    if (etl::is_even(current_length)) {
+        return {};
+    }
+    return stream.write(static_cast<uint8_t>(0U)) ? etl::expected<void, FrameWriteError>()
+                                                  : etl::unexpected(FrameWriteError::BufferTooShort);
+}
+
+/**
+ * @brief Write the CRC (16 or 32-bit) over the stream content after the preamble into the stream (big-endian).
+ */
+etl::expected<void, FrameWriteError> WriteCrc(etl::byte_stream_writer& stream, const Frame& frame,
+                                              const etl::span<const uint8_t>& crc_region) {
+    size_t section_length;
+    if (!frame.TryGetPayloadSectionLength(section_length)) {
+        return etl::unexpected(FrameWriteError::InvalidPayloadLength);
+    }
+    const size_t crc_size = GetCrcLengthFromPayloadLength(section_length);
+
+    if (crc_size == LONG_CRC_SIZE) {
+        const uint32_t v = algorithms::ComputeCrc32(crc_region);
+        return stream.write(v) ? etl::expected<void, FrameWriteError>()
+                               : etl::unexpected(FrameWriteError::BufferTooShort);
+    }
+    if (crc_size == SHORT_CRC_SIZE) {
+        const uint16_t v = algorithms::ComputeCrc16(crc_region);
+        return stream.write(v) ? etl::expected<void, FrameWriteError>()
+                               : etl::unexpected(FrameWriteError::BufferTooShort);
+    }
+    return etl::unexpected(FrameWriteError::InvalidPayloadLength);  // should never happen
+}
+
+}  // namespace impl
+
+using namespace spiopen::frame_writer::impl;
+
+// --- Public API ---
+etl::expected<void, FrameWriteError> WriteFrame(etl::byte_stream_writer& stream, const Frame& frame) {
+    auto valid = ValidateFrame(stream, frame);
+    if (!valid) {
+        return etl::unexpected(valid.error());
+    }
+
+    size_t start_position = stream.used_data().size();
+
+    auto pre = WritePreamble(stream);
+    if (!pre) {
+        return etl::unexpected(pre.error());
+    }
+
+    auto hdr = WriteFormatHeader(stream, frame);
+    if (!hdr) {
+        return etl::unexpected(hdr.error());
+    }
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    if (frame.can_flags.XLF) {
+        auto xl = WriteXlDataAndControl(stream, frame);
+        if (!xl) {
+            return etl::unexpected(xl.error());
+        }
+    }
+#endif
+
+    auto cid = WriteCanIdentifier(stream, frame);
+    if (!cid) {
+        return etl::unexpected(cid.error());
+    }
+
+    auto ttl = WriteTimeToLive(stream, frame);
+    if (!ttl) {
+        return etl::unexpected(ttl.error());
+    }
+
+    auto pay = WritePayload(stream, frame);
+    if (!pay) {
+        return etl::unexpected(pay.error());
+    }
+
+    auto pad = WriteFramePadding(stream, frame);
+    if (!pad) {
+        return etl::unexpected(pad.error());
+    }
+    auto crc_region = stream.used_data().subspan(PREAMBLE_SIZE + start_position);
+    auto crc =
+        WriteCrc(stream, frame,
+                 etl::span<const uint8_t>(reinterpret_cast<const uint8_t*>(crc_region.data()), crc_region.size()));
+    if (!crc) {
+        return etl::unexpected(crc.error());
+    }
+
+    return {};
+}
+
+}  // namespace spiopen::frame_writer

--- a/Libraries/SpIOpen_Frame/tests/CMakeLists.txt
+++ b/Libraries/SpIOpen_Frame/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.14)
+project(spiopen_frame_tests CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Fetch GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG main # Use "main" or a specific commit hash/tag
+)
+
+FetchContent_MakeAvailable(googletest)
+
+file(GLOB SPIOPEN_FRAME_TESTS_SOURCES "*.cpp")
+add_executable(spiopen_frame_tests ${SPIOPEN_FRAME_TESTS_SOURCES})
+target_link_libraries(spiopen_frame_tests PRIVATE spiopen_frame gtest gtest_main)
+
+# automatically discover CTest tests in the project
+include(GoogleTest)
+gtest_discover_tests(spiopen_frame_tests)

--- a/Libraries/SpIOpen_Frame/tests/spiopen_frame_algorithms_tests.cpp
+++ b/Libraries/SpIOpen_Frame/tests/spiopen_frame_algorithms_tests.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "etl/span.h"
+#include "spiopen_frame_algorithms.h"
+
+using namespace spiopen::algorithms;
+
+TEST(SpIOpen_Algorithms, CrcEncodingAccuracy) {
+    static constexpr uint8_t example_data_to_crc[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    static constexpr etl::span<const uint8_t> example_data_to_crc_span(example_data_to_crc);
+    static constexpr uint16_t expected_crc16 = 0x29B1U;
+    static constexpr uint32_t expected_crc32 = 0x0376E6E7U;
+
+    EXPECT_EQ(ComputeCrc16(example_data_to_crc_span), expected_crc16) << "CRC16 encoding accuracy";
+    EXPECT_EQ(ComputeCrc32(example_data_to_crc_span), expected_crc32) << "CRC32 encoding accuracy";
+}
+
+TEST(SpIOpen_Algorithms, SecdedEncodingAccuracy) {
+    static constexpr uint16_t kRaw = 0x0123U;  // 0b001'0010'0011
+    // check with http://www.mathaddict.net/hamming.htm, but note that they put the parity bits at LSb and we put them
+    // at MSb
+    static constexpr uint16_t expected_encoded = 0b1000'1001'0010'0011;
+    const uint16_t encoded = Secded16Encode11(kRaw);
+    EXPECT_EQ(encoded, expected_encoded) << "SECDED encoding accuracy";
+}
+
+TEST(SpIOpen_Algorithms, SecdedRoundTrip) {
+    static constexpr uint16_t bitmask_11 = 0x07FFU;
+    // loop by a prime number that is approx log(2^11) to cover most of the possible bit organizations
+    for (uint16_t raw11 = 0U; raw11 <= bitmask_11; raw11 = static_cast<uint16_t>(raw11 + 73U)) {
+        const uint16_t encoded = spiopen::algorithms::Secded16Encode11(raw11);
+        const Secded16DecodeResult decoded = spiopen::algorithms::Secded16Decode11(encoded);
+        EXPECT_EQ(encoded & bitmask_11, raw11)
+            << "SECDED maintain valueat lowest 11 bits";  // verify that the least significant 11 bits remain the same
+        EXPECT_FALSE(decoded.corrected);
+        EXPECT_FALSE(decoded.uncorrectable);
+        EXPECT_EQ(decoded.data11, raw11) << "SECDED roundtrip accuracy";
+    }
+}
+
+TEST(SpIOpen_Algorithms, SecdedSingleBitCorrection) {
+    // alternating bits within the 11 bits of relevant data
+    static constexpr uint16_t kRaw = 0x0555U;
+    const uint16_t encoded = spiopen::algorithms::Secded16Encode11(kRaw);
+
+    // test all possible single bit corruption
+    for (uint8_t bit = 0U; bit < 16U; ++bit) {
+        const uint16_t corrupted = static_cast<uint16_t>(encoded ^ (1U << bit));
+        const Secded16DecodeResult decoded = spiopen::algorithms::Secded16Decode11(corrupted);
+        EXPECT_EQ(decoded.data11, kRaw) << "SECDED single bit correction accuracy for bit #" << bit;
+        EXPECT_TRUE(decoded.corrected);
+        EXPECT_FALSE(decoded.uncorrectable);
+    }
+}
+
+TEST(SpIOpen_Algorithms, SecdedDoubleBitDetect) {
+    static constexpr uint16_t kRaw = 0x0555U;
+    const uint16_t encoded = spiopen::algorithms::Secded16Encode11(kRaw);
+
+    for (uint8_t i = 0U; i < 16U; ++i) {
+        for (size_t j = static_cast<size_t>(i) + 1U; j < 16U; ++j) {
+            const uint16_t corrupted = static_cast<uint16_t>(encoded ^ (1U << i) ^ (1U << j));
+            const Secded16DecodeResult decoded = spiopen::algorithms::Secded16Decode11(corrupted);
+            EXPECT_TRUE(decoded.uncorrectable) << "SECDED double bit detect accuracy for bits #" << i << " and #" << j;
+        }
+    }
+}

--- a/Libraries/SpIOpen_Frame/tests/spiopen_frame_buffer_tests.cpp
+++ b/Libraries/SpIOpen_Frame/tests/spiopen_frame_buffer_tests.cpp
@@ -1,0 +1,352 @@
+#include <etl/byte_stream.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "spiopen_frame.h"
+#include "spiopen_frame_buffer.h"
+#include "spiopen_frame_format.h"
+#include "spiopen_frame_reader.h"
+#include "spiopen_frame_writer.h"
+
+using namespace spiopen;
+using namespace spiopen::format;
+using namespace spiopen::frame_reader::impl;
+
+TEST(SpIOpen_FrameBuffer, ConstructorAndFields) {
+    etl::span<uint8_t> empty_span;
+    FrameBuffer empty_buffer = FrameBuffer(empty_span);
+    EXPECT_EQ(empty_buffer.GetBuffer().data(), nullptr) << "Buffer data";
+    EXPECT_EQ(empty_buffer.GetBuffer().size(), 0U) << "Buffer length";
+
+    uint8_t* buffer_data = new uint8_t[8]{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+    etl::span<uint8_t> buffer_span(buffer_data, 8U);
+    FrameBuffer test_buffer = FrameBuffer(buffer_span);
+    EXPECT_EQ(test_buffer.GetBuffer().data(), buffer_data) << "Buffer data";
+    EXPECT_EQ(test_buffer.GetBuffer().size(), 8U) << "Buffer length";
+}
+
+TEST(SpIOpen_FrameBuffer, WriteInternalBuffer) {
+    // --- Success: minimal CC frame with 2-byte payload, buffer large enough ---
+    {
+        constexpr size_t kBufferSize = 64;
+        uint8_t buffer[kBufferSize] = {0};
+        etl::span<uint8_t> buffer_span(buffer, kBufferSize);
+        FrameBuffer fb(buffer_span);
+
+        uint8_t payload_data[] = {0xAB, 0xCD};
+        Frame& frame = fb.GetFrame();
+        frame.can_flags = {};
+        frame.can_identifier = 0x123U;
+        frame.payload = etl::span<uint8_t>(payload_data, 2);
+
+        auto ret = fb.WriteInternalBuffer();
+        ASSERT_TRUE(ret) << "WriteInternalBuffer should succeed for valid CC frame with sufficient buffer";
+
+        EXPECT_EQ(buffer[0], PREAMBLE_BYTE) << "first byte of internal buffer should be preamble";
+        EXPECT_EQ(buffer[1], PREAMBLE_BYTE) << "second byte of internal buffer should be preamble";
+        // Payload appears after preamble + format header + CAN ID (2+2+2 = 6 bytes)
+        size_t payload_offset = PREAMBLE_SIZE + FORMAT_HEADER_SIZE + CAN_IDENTIFIER_SIZE;
+        EXPECT_EQ(buffer[payload_offset], 0xAB) << "first payload byte in buffer should match written frame";
+        EXPECT_EQ(buffer[payload_offset + 1], 0xCD) << "second payload byte in buffer should match written frame";
+    }
+
+    // --- Success: empty payload (zero-length frame) ---
+    {
+        constexpr size_t kBufferSize = 32;
+        uint8_t buffer[kBufferSize] = {0};
+        etl::span<uint8_t> buffer_span(buffer, kBufferSize);
+        FrameBuffer fb(buffer_span);
+
+        Frame& frame = fb.GetFrame();
+        frame.can_flags = {};
+        frame.can_identifier = 0;
+        frame.payload = etl::span<uint8_t>();
+
+        auto ret = fb.WriteInternalBuffer();
+        ASSERT_TRUE(ret) << "WriteInternalBuffer should succeed for frame with empty payload";
+        EXPECT_EQ(buffer[0], PREAMBLE_BYTE) << "internal buffer should start with preamble";
+    }
+
+    // --- Failure: buffer too short for frame ---
+    {
+        constexpr size_t kBufferSize = 32;
+        uint8_t buffer[kBufferSize] = {0};
+        etl::span<uint8_t> buffer_span(buffer, 8);  // only 8 bytes available
+        FrameBuffer fb(buffer_span);
+
+        uint8_t payload_data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+        Frame& frame = fb.GetFrame();
+        frame.can_flags = {};
+        frame.can_identifier = 0x100U;
+        frame.payload = etl::span<uint8_t>(payload_data, 6);
+
+        auto ret = fb.WriteInternalBuffer();
+        EXPECT_FALSE(ret) << "WriteInternalBuffer should fail when internal buffer is too short for frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_writer::FrameWriteError::BufferTooShort)
+                << "error should be BufferTooShort when buffer too small";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameBuffer, ReadInternalBuffer) {
+    // --- Success: buffer contains valid CC frame; read and check frame fields and payload ---
+    {
+        constexpr size_t kBufferSize = 64;
+        uint8_t buffer[kBufferSize] = {0};
+        etl::span<uint8_t> buffer_span(buffer, kBufferSize);
+
+        // Build a valid frame and write it into the buffer using the writer
+        uint8_t payload_data[] = {0x11, 0x22};
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0x300U;
+        frame_to_write.payload = etl::span<uint8_t>(payload_data, 2);
+
+        etl::byte_stream_writer writer(buffer_span, etl::endian::big);
+        auto write_ret = frame_writer::WriteFrame(writer, frame_to_write);
+        ASSERT_TRUE(write_ret) << "WriteFrame must succeed to populate buffer for ReadInternalBuffer test";
+
+        FrameBuffer fb(buffer_span);
+        auto ret = fb.ReadInternalBuffer();
+        ASSERT_TRUE(ret)
+            << "ReadInternalBuffer should succeed when buffer holds valid serialized frame (parse error code: "
+            << static_cast<std::underlying_type_t<frame_reader::FrameParseError>>(ret.error()) << ")";
+
+        Frame& read_frame = fb.GetFrame();
+        EXPECT_EQ(read_frame.can_identifier, 0x300U) << "read frame can_identifier should match written value";
+        EXPECT_FALSE(read_frame.payload.empty()) << "read frame payload span should be non-empty for 2-byte payload";
+        EXPECT_EQ(read_frame.payload.size(), 2U) << "read frame payload size should be 2";
+        EXPECT_EQ(read_frame.payload.data(), buffer + (PREAMBLE_SIZE + FORMAT_HEADER_SIZE + CAN_IDENTIFIER_SIZE))
+            << "payload should point into internal buffer after preamble and header";
+        EXPECT_EQ(read_frame.payload[0], 0x11) << "first payload byte in read frame should match written data";
+        EXPECT_EQ(read_frame.payload[1], 0x22) << "second payload byte in read frame should match written data";
+    }
+
+    // --- Success: frame with zero-length payload ---
+    {
+        constexpr size_t kBufferSize = 32;
+        uint8_t buffer[kBufferSize] = {0};
+        etl::span<uint8_t> buffer_span(buffer, kBufferSize);
+
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0;
+        frame_to_write.payload = etl::span<uint8_t>();
+
+        etl::byte_stream_writer writer(buffer_span, etl::endian::big);
+        auto write_ret = frame_writer::WriteFrame(writer, frame_to_write);
+        ASSERT_TRUE(write_ret) << "WriteFrame must succeed for empty-payload frame";
+
+        FrameBuffer fb(buffer_span);
+        auto ret = fb.ReadInternalBuffer();
+        ASSERT_TRUE(ret) << "ReadInternalBuffer should succeed for buffer containing empty-payload frame";
+        EXPECT_TRUE(fb.GetFrame().payload.empty()) << "read frame payload should be empty";
+    }
+
+    // --- Failure: buffer too short to parse (truncated) ---
+    {
+        uint8_t buffer[] = {PREAMBLE_BYTE, PREAMBLE_BYTE};  // only preamble, no format header
+        etl::span<uint8_t> buffer_span(buffer, sizeof(buffer));
+        FrameBuffer fb(buffer_span);
+
+        auto ret = fb.ReadInternalBuffer();
+        EXPECT_FALSE(ret) << "ReadInternalBuffer should fail when buffer is truncated before full header";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortToDetermineLength)
+                << "error should be BufferTooShortToDetermineLength for truncated buffer";
+        }
+    }
+
+    // --- Failure: no valid preamble at start ---
+    {
+        constexpr size_t kBufferSize = 16;
+        uint8_t buffer[kBufferSize] = {0};
+        buffer[0] = 0x00;
+        buffer[1] = 0x00;
+        etl::span<uint8_t> buffer_span(buffer, kBufferSize);
+        FrameBuffer fb(buffer_span);
+
+        auto ret = fb.ReadInternalBuffer();
+        EXPECT_FALSE(ret) << "ReadInternalBuffer should fail when buffer does not start with valid preamble";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::NoPreamble)
+                << "error should be NoPreamble when first bytes are not 0xAA 0xAA";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameBuffer, LoadAndReadInternalBuffer) {
+    // --- Success: input stream with valid frame, bit_slip_count 0 ---
+    {
+        constexpr size_t kInputSize = 64;
+        constexpr size_t kBufferSize = 64;
+        uint8_t input_buf[kInputSize] = {0};
+        uint8_t internal_buf[kBufferSize] = {0};
+
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0x50U;
+        uint8_t payload_data[] = {0xDD, 0xEE};
+        frame_to_write.payload = etl::span<uint8_t>(payload_data, 2);
+
+        etl::byte_stream_writer writer(etl::span<uint8_t>(input_buf, kInputSize), etl::endian::big);
+        auto write_ret = frame_writer::WriteFrame(writer, frame_to_write);
+        ASSERT_TRUE(write_ret) << "WriteFrame must succeed to build input stream for LoadAndReadInternalBuffer";
+
+        etl::byte_stream_reader input_stream(input_buf, kInputSize, etl::endian::big);
+        FrameBuffer fb(etl::span<uint8_t>(internal_buf, kBufferSize));
+
+        auto ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        ASSERT_TRUE(ret) << "LoadAndReadInternalBuffer should succeed when input stream has valid frame (error: "
+                         << static_cast<int>(ret.error()) << ")";
+
+        Frame& read_frame = fb.GetFrame();
+        EXPECT_EQ(read_frame.can_identifier, 0x50U) << "read frame can_identifier should match frame in input stream";
+        EXPECT_EQ(read_frame.payload.size(), 2U) << "read frame payload size should be 2";
+        EXPECT_EQ(read_frame.payload[0], 0xDD) << "payload byte 0 should match after load and read";
+        EXPECT_EQ(read_frame.payload[1], 0xEE) << "payload byte 1 should match after load and read";
+        EXPECT_TRUE(read_frame.payload.data() >= internal_buf && read_frame.payload.data() < internal_buf + kBufferSize)
+            << "payload should point into internal buffer after LoadAndReadInternalBuffer";
+    }
+
+    // --- Success: 1-bit slipped data in input_buf, CopyFromBitSlippedBuffer moves to slipped_buf, then parse ---
+    {
+        constexpr size_t kInputSize = 64;
+        constexpr size_t kBufferSize = 64;
+        uint8_t input_buf[kInputSize] = {0};
+        uint8_t slipped_buf[kInputSize] = {0};
+        uint8_t internal_buf[kBufferSize] = {0};
+
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0x50U;
+        uint8_t payload_data[] = {0xDD, 0xEE};
+        frame_to_write.payload = etl::span<uint8_t>(payload_data, 2);
+
+        etl::byte_stream_writer writer(etl::span<uint8_t>(input_buf + 1, kInputSize - 1),
+                                       etl::endian::big);  // leave first byte blank for bit slip pointing later
+        auto write_ret = frame_writer::WriteFrame(writer, frame_to_write);
+        ASSERT_TRUE(write_ret) << "WriteFrame must succeed to build input for bit-slip test";
+
+        const size_t frame_len = writer.size_bytes();
+
+        // Move frame from (slipped) input_buf to slipped_buf using CopyFromBitSlippedBuffer with bit_slip_count 1.
+        etl::byte_stream_reader input_reader(input_buf, kInputSize, etl::endian::big);
+        etl::byte_stream_writer slipped_writer(etl::span<uint8_t>(slipped_buf, kBufferSize), etl::endian::big);
+        const bool copy_ok = CopyFromBitSlippedBuffer(input_reader, slipped_writer, frame_len,
+                                                      7);  // shift left by 7 bits to leave one bit of simulated slip
+        ASSERT_TRUE(copy_ok) << "CopyFromBitSlippedBuffer should succeed moving slipped frame into slipped_buf";
+
+        etl::byte_stream_reader slipped_stream(slipped_buf, kInputSize, etl::endian::big);
+        FrameBuffer fb(etl::span<uint8_t>(internal_buf, kBufferSize));
+
+        auto ret = fb.LoadAndReadInternalBuffer(slipped_stream, 1);
+        ASSERT_TRUE(ret) << "LoadAndReadInternalBuffer should succeed after CopyFromBitSlippedBuffer corrected into "
+                            "slipped_buf (error: "
+                         << static_cast<int>(ret.error()) << ")";
+
+        Frame& read_frame = fb.GetFrame();
+        EXPECT_EQ(read_frame.can_identifier, 0x50U) << "read frame can_identifier should match after slip correction";
+        EXPECT_EQ(read_frame.payload.size(), 2U) << "read frame payload size should be 2 after slip correction";
+        EXPECT_EQ(read_frame.payload[0], 0xDD) << "payload byte 0 should match after load and read with bit slip";
+        EXPECT_EQ(read_frame.payload[1], 0xEE) << "payload byte 1 should match after load and read with bit slip";
+        EXPECT_TRUE(read_frame.payload.data() >= internal_buf && read_frame.payload.data() < internal_buf + kBufferSize)
+            << "payload should point into internal buffer after LoadAndReadInternalBuffer with bit slip";
+    }
+
+    // --- Success: default bit_slip_count (0) ---
+    {
+        constexpr size_t kInputSize = 32;
+        constexpr size_t kBufferSize = 32;
+        uint8_t input_buf[kInputSize] = {0};
+        uint8_t internal_buf[kBufferSize] = {0};
+
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0;
+        frame_to_write.payload = etl::span<uint8_t>();
+
+        etl::byte_stream_writer writer(etl::span<uint8_t>(input_buf, kInputSize), etl::endian::big);
+        ASSERT_TRUE(frame_writer::WriteFrame(writer, frame_to_write));
+
+        etl::byte_stream_reader input_stream(input_buf, kInputSize, etl::endian::big);
+        FrameBuffer fb(etl::span<uint8_t>(internal_buf, kBufferSize));
+
+        auto ret = fb.LoadAndReadInternalBuffer(input_stream);
+        ASSERT_TRUE(ret) << "LoadAndReadInternalBuffer should succeed with default bit_slip_count (0)";
+        EXPECT_TRUE(fb.GetFrame().payload.empty()) << "read frame payload should be empty for empty-payload frame";
+    }
+
+    // --- Failure: input stream too short (no complete frame) ---
+    {
+        uint8_t input_buf[] = {PREAMBLE_BYTE, PREAMBLE_BYTE};
+        uint8_t internal_buf[32] = {0};
+        etl::byte_stream_reader input_stream(input_buf, sizeof(input_buf), etl::endian::big);
+        FrameBuffer fb(etl::span<uint8_t>(internal_buf, sizeof(internal_buf)));
+
+        auto ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        EXPECT_FALSE(ret) << "LoadAndReadInternalBuffer should fail when input stream does not contain full frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortToDetermineLength)
+                << "error should reflect truncated input when stream too short";
+        }
+    }
+
+    // --- Failure: internal buffer too short to hold copied frame ---
+    {
+        constexpr size_t kInputSize = 64;
+        uint8_t input_buf[kInputSize] = {0};
+        uint8_t internal_buf[kInputSize] = {0};  // too small for any full frame
+
+        Frame frame_to_write{};
+        frame_to_write.can_flags = {};
+        frame_to_write.can_identifier = 0x100U;
+        uint8_t payload_data[] = {0x01, 0x02};
+        frame_to_write.payload = etl::span<uint8_t>(payload_data, 2);
+
+        etl::byte_stream_writer writer(etl::span<uint8_t>(input_buf, kInputSize), etl::endian::big);
+        ASSERT_TRUE(frame_writer::WriteFrame(writer, frame_to_write));
+
+        etl::byte_stream_reader input_stream(input_buf, kInputSize, etl::endian::big);
+
+        // too short for preamble
+        FrameBuffer fb(etl::span<uint8_t>(internal_buf, 1));
+        input_stream.restart(0);
+        auto ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        EXPECT_FALSE(ret) << "LoadAndReadInternalBuffer should fail when internal buffer is too short to copy frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortForPreamble);
+        }
+
+        // too short to determine length (first part of header)
+        fb.SetBuffer(etl::span<uint8_t>(internal_buf, 3));
+        input_stream.restart(0);
+        ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        EXPECT_FALSE(ret) << "LoadAndReadInternalBuffer should fail when internal buffer is too short to copy frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortToDetermineLength);
+        }
+
+        // too short for header (second part of header)
+        fb.SetBuffer(etl::span<uint8_t>(internal_buf, 5));
+        input_stream.restart(0);
+        ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        EXPECT_FALSE(ret) << "LoadAndReadInternalBuffer should fail when internal buffer is too short to copy frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortForHeader);
+        }
+
+        // too short for payload
+        fb.SetBuffer(etl::span<uint8_t>(internal_buf, 7));
+        input_stream.restart(0);
+        ret = fb.LoadAndReadInternalBuffer(input_stream, 0);
+        EXPECT_FALSE(ret) << "LoadAndReadInternalBuffer should fail when internal buffer is too short to copy frame";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), frame_reader::FrameParseError::BufferTooShortForPayload);
+        }
+    }
+}

--- a/Libraries/SpIOpen_Frame/tests/spiopen_frame_reader_tests.cpp
+++ b/Libraries/SpIOpen_Frame/tests/spiopen_frame_reader_tests.cpp
@@ -1,0 +1,511 @@
+#include <etl/byte_stream.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "spiopen_frame.h"
+#include "spiopen_frame_algorithms.h"
+#include "spiopen_frame_format.h"
+#include "spiopen_frame_reader.h"
+
+using namespace spiopen;
+using namespace spiopen::format;
+using namespace spiopen::frame_reader;
+using namespace spiopen::frame_reader::impl;
+
+static uint16_t EncodeFormatHeader11(uint8_t dlc_nibble, bool IDE, bool FDF, bool XLF, bool TTL, bool WA) {
+    const uint16_t low = (dlc_nibble & HEADER_DLC_MASK) | (IDE ? HEADER_IDE_MASK : 0U) | (FDF ? HEADER_FDF_MASK : 0U) |
+                         (XLF ? HEADER_XLF_MASK : 0U) | (TTL ? HEADER_TTL_MASK : 0U);
+    const uint16_t high = WA ? HEADER_WA_MASK : 0U;
+    return algorithms::Secded16Encode11(low | (high << 8U));
+}
+
+TEST(SpIOpen_FrameReader, ParseFormatHeader) {
+    {
+        // CC frame: DLC=2, no flags
+        const uint16_t encoded = EncodeFormatHeader11(2, false, false, false, false, false);
+        const uint8_t high = static_cast<uint8_t>(encoded >> 8U);
+        const uint8_t low = static_cast<uint8_t>(encoded & 0xFFU);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 0;
+        auto ret = ParseFormatHeader(high, low, frame, dlc_corrected, payload_len);
+        ASSERT_TRUE(ret) << "ParseFormatHeader should succeed for valid CC header";
+        EXPECT_EQ(payload_len, 2U) << "payload_len should be 2 for DLC=2 CC header";
+        EXPECT_FALSE(frame.can_flags.IDE) << "IDE should be clear for CC header with no IDE";
+        EXPECT_FALSE(frame.can_flags.FDF) << "FDF should be clear for CC header";
+        EXPECT_FALSE(frame.can_flags.XLF) << "XLF should be clear for CC header";
+        EXPECT_FALSE(frame.can_flags.TTL) << "TTL should be clear for CC header";
+        EXPECT_FALSE(frame.can_flags.WA) << "WA should be clear for CC header with no WA";
+    }
+
+    {
+        // Header with IDE, WA set; DLC=0
+        const uint16_t encoded = EncodeFormatHeader11(0, true, false, false, false, true);
+        const uint8_t high = static_cast<uint8_t>(encoded >> 8U);
+        const uint8_t low = static_cast<uint8_t>(encoded & 0xFFU);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 99;
+        auto ret = ParseFormatHeader(high, low, frame, dlc_corrected, payload_len);
+        ASSERT_TRUE(ret) << "ParseFormatHeader should succeed for header with IDE and WA set";
+        EXPECT_EQ(payload_len, 0U) << "payload_len should be 0 for DLC=0";
+        EXPECT_TRUE(frame.can_flags.IDE) << "IDE should be set from header";
+        EXPECT_TRUE(frame.can_flags.WA) << "WA should be set from header";
+    }
+
+    {
+        // Corrupted (invalid SECDED): flip two bits so uncorrectable
+        const uint16_t encoded = EncodeFormatHeader11(1, false, false, false, false, false);
+        const uint16_t corrupted = encoded ^ 0x0300U;  // two bit flips
+        const uint8_t high = static_cast<uint8_t>(corrupted >> 8U);
+        const uint8_t low = static_cast<uint8_t>(corrupted & 0xFFU);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 0;
+        auto ret = ParseFormatHeader(high, low, frame, dlc_corrected, payload_len);
+        EXPECT_FALSE(ret) << "ParseFormatHeader should fail for uncorrectable SECDED corruption";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::FormatDlcCorrupted) << "error should be FormatDlcCorrupted";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, ValidatePreamble) {
+    {
+        const uint8_t buffer[] = {PREAMBLE_BYTE, PREAMBLE_BYTE};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        auto ret = ValidatePreamble(stream);
+        ASSERT_TRUE(ret) << "ValidatePreamble should succeed for valid preamble";
+    }
+
+    {
+        const uint8_t buffer[] = {PREAMBLE_BYTE};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        auto ret = ValidatePreamble(stream);
+        EXPECT_FALSE(ret) << "ValidatePreamble should fail when stream has only one byte";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForPreamble)
+                << "error should be BufferTooShortForPreamble";
+        }
+    }
+
+    {
+        const uint8_t buffer[] = {0x00, PREAMBLE_BYTE};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        auto ret = ValidatePreamble(stream);
+        EXPECT_FALSE(ret) << "ValidatePreamble should fail when first byte is not preamble";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::NoPreamble) << "error should be NoPreamble";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader,
+     ReadFormatHeader){{const uint16_t encoded = EncodeFormatHeader11(3, false, false, false, false, false);
+uint8_t buffer[4] = {0};
+buffer[0] = static_cast<uint8_t>(encoded >> 8U);
+buffer[1] = static_cast<uint8_t>(encoded & 0xFFU);
+etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+Frame frame{};
+bool dlc_corrected = false;
+size_t payload_len = 0;
+auto ret = ReadFormatHeader(stream, frame, dlc_corrected, payload_len);
+ASSERT_TRUE(ret) << "ReadFormatHeader should succeed with sufficient buffer";
+EXPECT_EQ(payload_len, 3U) << "payload_len should be 3 for DLC=3";
+}
+
+{
+    uint8_t buffer[1] = {0};
+    etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+    Frame frame{};
+    bool dlc_corrected = false;
+    size_t payload_len = 0;
+    auto ret = ReadFormatHeader(stream, frame, dlc_corrected, payload_len);
+    EXPECT_FALSE(ret) << "ReadFormatHeader should fail when stream cannot provide uint16_t";
+    if (!ret) {
+        EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortToDetermineLength)
+            << "error should be BufferTooShortToDetermineLength";
+    }
+}
+
+#ifndef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+{
+    const uint16_t encoded = EncodeFormatHeader11(0, false, true, false, false, false);
+    uint8_t buffer[4] = {0};
+    buffer[0] = static_cast<uint8_t>(encoded >> 8U);
+    buffer[1] = static_cast<uint8_t>(encoded & 0xFFU);
+    etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+    Frame frame{};
+    bool dlc_corrected = false;
+    size_t payload_len = 0;
+    auto ret = ReadFormatHeader(stream, frame, dlc_corrected, payload_len);
+    EXPECT_FALSE(ret) << "ReadFormatHeader should fail when FD not enabled and header has FDF set";
+    if (!ret) {
+        EXPECT_EQ(ret.error(), FrameParseError::CanFdNotSupported) << "error should be CanFdNotSupported";
+    }
+}
+#endif
+
+#ifndef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+{
+    const uint16_t encoded = EncodeFormatHeader11(0, false, false, true, false, false);
+    uint8_t buffer[4] = {0};
+    buffer[0] = static_cast<uint8_t>(encoded >> 8U);
+    buffer[1] = static_cast<uint8_t>(encoded & 0xFFU);
+    etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+    Frame frame{};
+    bool dlc_corrected = false;
+    size_t payload_len = 0;
+    auto ret = ReadFormatHeader(stream, frame, dlc_corrected, payload_len);
+    EXPECT_FALSE(ret) << "ReadFormatHeader should fail when XL not enabled and header has XLF set";
+    if (!ret) {
+        EXPECT_EQ(ret.error(), FrameParseError::CanXlNotSupported) << "error should be CanXlNotSupported";
+    }
+}
+#endif
+}
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+TEST(SpIOpen_FrameReader, ReadXlPayloadLength) {
+    {
+        const uint16_t encoded = algorithms::Secded16Encode11(10);
+        uint8_t buffer[4] = {0};
+        buffer[0] = static_cast<uint8_t>(encoded >> 8U);
+        buffer[1] = static_cast<uint8_t>(encoded & 0xFFU);
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 0;
+        auto ret = ReadXlPayloadLength(stream, frame, dlc_corrected, payload_len);
+        ASSERT_TRUE(ret) << "ReadXlPayloadLength should succeed for valid encoded length 10";
+        EXPECT_EQ(payload_len, 10U) << "payload_len_out should be 10";
+    }
+
+    {
+        uint8_t buffer[1] = {0};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 0;
+        auto ret = ReadXlPayloadLength(stream, frame, dlc_corrected, payload_len);
+        EXPECT_FALSE(ret) << "ReadXlPayloadLength should fail when stream cannot provide uint16_t";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortToDetermineLength)
+                << "error should be BufferTooShortToDetermineLength";
+        }
+    }
+
+    {
+        // 11-bit SECDED max is 2047; decoded 2047 is valid. Test uncorrectable corruption instead.
+        const uint16_t encoded = algorithms::Secded16Encode11(100);
+        const uint16_t corrupted = encoded ^ 0x0300U;  // two bit flips -> uncorrectable
+        uint8_t buffer[4] = {0};
+        buffer[0] = static_cast<uint8_t>(corrupted >> 8U);
+        buffer[1] = static_cast<uint8_t>(corrupted & 0xFFU);
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        bool dlc_corrected = false;
+        size_t payload_len = 0;
+        auto ret = ReadXlPayloadLength(stream, frame, dlc_corrected, payload_len);
+        EXPECT_FALSE(ret) << "ReadXlPayloadLength should fail for uncorrectable SECDED";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::FormatDlcCorrupted) << "error should be FormatDlcCorrupted";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, ReadXlControl) {
+    {
+        const uint8_t payload_type = 0x12;
+        const uint8_t vcid = 0x34;
+        const uint32_t addr = 0x12345678U;
+        uint8_t buffer[8] = {0};
+        buffer[0] = payload_type;
+        buffer[1] = vcid;
+        buffer[2] = static_cast<uint8_t>(addr >> 24);
+        buffer[3] = static_cast<uint8_t>(addr >> 16);
+        buffer[4] = static_cast<uint8_t>(addr >> 8);
+        buffer[5] = static_cast<uint8_t>(addr);
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        auto ret = ReadXlControl(stream, frame);
+        ASSERT_TRUE(ret) << "ReadXlControl should succeed with 6 bytes in stream";
+        EXPECT_EQ(frame.xl_control.payload_type, payload_type) << "payload_type should match stream";
+        EXPECT_EQ(frame.xl_control.virtual_can_network_id, vcid) << "virtual_can_network_id should match stream";
+        EXPECT_EQ(frame.xl_control.addressing_field, addr) << "addressing_field should match stream";
+    }
+
+    {
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        auto ret = ReadXlControl(stream, frame);
+        EXPECT_FALSE(ret) << "ReadXlControl should fail when stream has fewer than 6 bytes";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForHeader)
+                << "error should be BufferTooShortForHeader";
+        }
+    }
+}
+#endif
+
+TEST(SpIOpen_FrameReader, ReadCanID) {
+    {
+        // Standard ID 0x7FF, big-endian: 0x07 0xFF
+        const uint8_t buffer[] = {0x07U, 0xFFU};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        frame.can_flags.IDE = 0;
+        auto ret = ReadCanID(stream, frame);
+        ASSERT_TRUE(ret) << "ReadCanID should succeed for standard ID with 2 bytes in stream";
+        EXPECT_EQ(frame.can_identifier, 0x7FFU) << "can_identifier should be 0x7FF for 0x07 0xFF big-endian";
+    }
+
+    {
+        // Extended ID, big-endian 4 bytes
+        const uint8_t buffer[] = {0x1FU, 0xFFU, 0xFFU, 0xFFU};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        frame.can_flags.IDE = 1;
+        auto ret = ReadCanID(stream, frame);
+        ASSERT_TRUE(ret) << "ReadCanID should succeed for extended ID with 4 bytes in stream";
+        EXPECT_EQ(frame.can_identifier, 0x1FFFFFFFU) << "can_identifier should be 0x1FFFFFFF for extended";
+    }
+
+    {
+        uint8_t buffer[1] = {0};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        frame.can_flags.IDE = 0;
+        auto ret = ReadCanID(stream, frame);
+        EXPECT_FALSE(ret) << "ReadCanID should fail when stream has only 1 byte for standard ID";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForHeader)
+                << "error should be BufferTooShortForHeader";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, ReadTTL) {
+    {
+        const uint8_t buffer[] = {5};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        auto ret = ReadTTL(stream, frame);
+        ASSERT_TRUE(ret) << "ReadTTL should succeed when stream has one byte";
+        EXPECT_EQ(frame.time_to_live, 5U) << "time_to_live should be 5";
+    }
+
+    {
+        const uint8_t buffer[1] = {0};
+        etl::byte_stream_reader stream(static_cast<const void*>(buffer), size_t(0), etl::endian::big);
+        Frame frame{};
+        auto ret = ReadTTL(stream, frame);
+        EXPECT_FALSE(ret) << "ReadTTL should fail when stream is empty";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForHeader)
+                << "error should be BufferTooShortForHeader";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, ValidateCRC) {
+    {
+        // Build minimal frame + crc_region (e.g. 2 bytes), compute CRC16, put CRC in stream
+        uint8_t crc_region_data[] = {0x01, 0x02};
+        const uint16_t crc16 = algorithms::ComputeCrc16(etl::span<const uint8_t>(crc_region_data, 2));
+        uint8_t stream_buf[4] = {0};
+        stream_buf[0] = static_cast<uint8_t>(crc16 >> 8U);
+        stream_buf[1] = static_cast<uint8_t>(crc16 & 0xFFU);
+        etl::byte_stream_reader stream(stream_buf, sizeof(stream_buf), etl::endian::big);
+        Frame frame{};
+        frame.can_flags = {};
+        uint8_t payload_storage[2] = {0x01, 0x02};
+        frame.payload = etl::span<uint8_t>(payload_storage, 2);
+        const etl::span<const uint8_t> crc_region(crc_region_data, 2);
+        auto ret = ValidateCRC(stream, frame, crc_region);
+        ASSERT_TRUE(ret) << "ValidateCRC should succeed when CRC16 matches";
+    }
+
+    {
+        uint8_t crc_region_data[] = {0x01, 0x02};
+        uint8_t stream_buf[] = {0x00, 0x00};  // wrong CRC
+        etl::byte_stream_reader stream(stream_buf, sizeof(stream_buf), etl::endian::big);
+        Frame frame{};
+        frame.can_flags = {};
+        uint8_t payload_storage[2] = {0x01, 0x02};
+        frame.payload = etl::span<uint8_t>(payload_storage, 2);
+        const etl::span<const uint8_t> crc_region(crc_region_data, 2);
+        auto ret = ValidateCRC(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "ValidateCRC should fail when stream CRC does not match computed CRC";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::CrcMismatch) << "error should be CrcMismatch";
+        }
+    }
+
+    {
+        const uint8_t buffer[1] = {0};
+        etl::byte_stream_reader stream(buffer, sizeof(buffer), etl::endian::big);
+        Frame frame{};
+        frame.can_flags = {};
+        uint8_t payload_storage[2] = {0};
+        frame.payload = etl::span<uint8_t>(payload_storage, 2);
+        etl::span<const uint8_t> crc_region(payload_storage, 2);
+        auto ret = ValidateCRC(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "ValidateCRC should fail when stream cannot provide 2-byte CRC16";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForPayload)
+                << "error should be BufferTooShortForPayload";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, CopyFromBitSlippedBuffer) {
+    {
+        // bit_slip_count 0: plain copy
+        uint8_t src_buf[] = {0xAA, 0xBB, 0xCC};
+        uint8_t dest_buf[8] = {0};
+        etl::byte_stream_reader src(src_buf, sizeof(src_buf), etl::endian::big);
+        etl::byte_stream_writer dest(etl::span<uint8_t>(dest_buf, sizeof(dest_buf)), etl::endian::big);
+        auto ret = CopyFromBitSlippedBuffer(src, dest, 3, 0);
+        ASSERT_TRUE(ret) << "CopyFromBitSlippedBuffer should succeed for bit_slip_count 0 with enough data";
+        EXPECT_EQ(dest_buf[0], 0xAA) << "first copied byte should be 0xAA";
+        EXPECT_EQ(dest_buf[1], 0xBB) << "second copied byte should be 0xBB";
+        EXPECT_EQ(dest_buf[2], 0xCC) << "third copied byte should be 0xCC";
+    }
+
+    {
+        // bit_slip_count 1: complement
+        uint8_t src_buf[] = {PREAMBLE_BYTE_COMPLEMENT, PREAMBLE_BYTE_COMPLEMENT, PREAMBLE_BYTE_COMPLEMENT};
+        uint8_t dest_buf[8] = {0};
+        etl::byte_stream_reader src(src_buf, sizeof(src_buf), etl::endian::big);
+        etl::byte_stream_writer dest(etl::span<uint8_t>(dest_buf, sizeof(dest_buf)), etl::endian::big);
+        auto ret = CopyFromBitSlippedBuffer(src, dest, 2, 1);
+        ASSERT_TRUE(ret) << "CopyFromBitSlippedBuffer should succeed for bit_slip_count 1 with enough data";
+        EXPECT_EQ(dest_buf[0], PREAMBLE_BYTE) << "first copied byte should be 0xAA";
+        EXPECT_EQ(dest_buf[1], PREAMBLE_BYTE) << "second copied byte should be 0xAA";
+    }
+
+    {
+        // bit_slip_count > 7: invalid
+        uint8_t src_buf[] = {0xAA, 0xBB};
+        uint8_t dest_buf[8] = {0};
+        etl::byte_stream_reader src(src_buf, sizeof(src_buf), etl::endian::big);
+        etl::byte_stream_writer dest(etl::span<uint8_t>(dest_buf, sizeof(dest_buf)), etl::endian::big);
+        auto ret = CopyFromBitSlippedBuffer(src, dest, 1, 8);
+        EXPECT_FALSE(ret) << "CopyFromBitSlippedBuffer should fail when bit_slip_count > 7";
+    }
+
+    {
+        // dest too small
+        uint8_t src_buf[] = {0xAA, 0xBB};
+        uint8_t dest_buf[1] = {0};
+        etl::byte_stream_reader src(src_buf, sizeof(src_buf), etl::endian::big);
+        etl::byte_stream_writer dest(etl::span<uint8_t>(dest_buf, sizeof(dest_buf)), etl::endian::big);
+        auto ret = CopyFromBitSlippedBuffer(src, dest, 2, 0);
+        EXPECT_FALSE(ret) << "CopyFromBitSlippedBuffer should fail when dest has fewer bytes than bytes_to_copy";
+    }
+
+    {
+        // source too small for bytes_to_copy
+        uint8_t src_buf[] = {0xAA};
+        uint8_t dest_buf[8] = {0};
+        etl::byte_stream_reader src(src_buf, sizeof(src_buf), etl::endian::big);
+        etl::byte_stream_writer dest(etl::span<uint8_t>(dest_buf, sizeof(dest_buf)), etl::endian::big);
+        auto ret = CopyFromBitSlippedBuffer(src, dest, 2, 0);
+        EXPECT_FALSE(ret) << "CopyFromBitSlippedBuffer should fail when source has fewer bytes than bytes_to_copy";
+    }
+}
+
+TEST(SpIOpen_FrameReader, FindNextPreambleByte) {
+    {
+        uint8_t buffer[] = {0x00, PREAMBLE_BYTE, 0x00};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = FindNextPreambleByte(buf_span, 0, false);
+        ASSERT_TRUE(ret) << "FindNextPreambleByte should find PREAMBLE_BYTE at index 1 when bit_slips_allowed false";
+        EXPECT_EQ(*ret, 1U) << "returned index should be 1";
+    }
+
+    {
+        uint8_t buffer[] = {0x00, PREAMBLE_BYTE_COMPLEMENT, 0x00};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = FindNextPreambleByte(buf_span, 0, true);
+        ASSERT_TRUE(ret) << "FindNextPreambleByte should find complement at index 1 when bit_slips_allowed true";
+        EXPECT_EQ(*ret, 1U) << "returned index should be 1";
+    }
+
+    {
+        uint8_t buffer[] = {0x00, 0x00};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = FindNextPreambleByte(buf_span, 0, false);
+        EXPECT_FALSE(ret) << "FindNextPreambleByte should fail when no preamble byte in buffer";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::NoPreamble) << "error should be NoPreamble";
+        }
+    }
+
+    {
+        uint8_t buffer[] = {0x00};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = FindNextPreambleByte(buf_span, 1, false);
+        EXPECT_FALSE(ret) << "FindNextPreambleByte should fail when offset >= buffer.size()";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForPreamble)
+                << "error should be BufferTooShortForPreamble";
+        }
+    }
+}
+
+TEST(SpIOpen_FrameReader, CountBitOffsetIntoPreviousByte) {
+    {
+        // Aligned 2-byte preamble at start
+        uint8_t buffer[] = {PREAMBLE_BYTE, PREAMBLE_BYTE};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = CountBitOffsetIntoPreviousByte(buf_span, 0);
+        ASSERT_TRUE(ret) << "CountBitOffsetIntoPreviousByte should succeed for aligned 2-byte preamble at start";
+        EXPECT_EQ(*ret, 0U) << "bit offset should be 0 when preamble is aligned";
+    }
+    {
+        // Even bit slip: pattern with preamble at index 1; bit offset from previous byte
+        uint8_t buffer[] = {PREAMBLE_BYTE >> 2, PREAMBLE_BYTE, PREAMBLE_BYTE};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = CountBitOffsetIntoPreviousByte(buf_span, 1);
+        ASSERT_TRUE(ret) << "CountBitOffsetIntoPreviousByte should succeed for even bit slip pattern";
+        EXPECT_EQ(*ret, 6U) << "bit offset value from implementation for this pattern";
+    }
+
+    {
+        // Odd bit slip (complement preamble at index 1)
+        uint8_t buffer[] = {PREAMBLE_BYTE_COMPLEMENT, PREAMBLE_BYTE_COMPLEMENT, PREAMBLE_BYTE_COMPLEMENT};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = CountBitOffsetIntoPreviousByte(buf_span, 1);
+        ASSERT_TRUE(ret) << "CountBitOffsetIntoPreviousByte should succeed for odd bit slip (complement)";
+        EXPECT_EQ(*ret, 7U) << "bit offset value from implementation for complement pattern";
+    }
+
+    {
+        // Buffer too short: preamble_index + 1 >= size
+        uint8_t buffer[] = {PREAMBLE_BYTE};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = CountBitOffsetIntoPreviousByte(buf_span, 0);
+        EXPECT_FALSE(ret) << "CountBitOffsetIntoPreviousByte should fail when buffer has no byte after preamble_index";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::BufferTooShortForPreamble)
+                << "error should be BufferTooShortForPreamble";
+        }
+    }
+
+    {
+        // First byte not matching second for 2-byte preamble at index 0
+        uint8_t buffer[] = {PREAMBLE_BYTE, 0x00};
+        etl::span<uint8_t> buf_span(buffer, sizeof(buffer));
+        auto ret = CountBitOffsetIntoPreviousByte(buf_span, 0);
+        EXPECT_FALSE(ret) << "CountBitOffsetIntoPreviousByte should fail when second byte is not preamble/complement";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameParseError::NoPreamble) << "error should be NoPreamble";
+        }
+    }
+}

--- a/Libraries/SpIOpen_Frame/tests/spiopen_frame_tests.cpp
+++ b/Libraries/SpIOpen_Frame/tests/spiopen_frame_tests.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "spiopen_frame.h"
+
+using namespace spiopen;
+
+TEST(SpIOpen_Frame, Reset) {
+    Frame frame;
+    // constructor resets everything, but not with the reset function...
+    EXPECT_EQ(frame.can_identifier, 0U) << "Frame identifier";
+    EXPECT_FALSE(frame.can_flags.IDE) << "Frame IDE flag";
+    EXPECT_FALSE(frame.can_flags.TTL) << "Frame TTL flag";
+    EXPECT_FALSE(frame.can_flags.XLF) << "Frame XLF flag";
+    EXPECT_FALSE(frame.can_flags.WA) << "Frame WA flag";
+    EXPECT_FALSE(frame.can_flags.FDF) << "Frame FDF flag";
+    EXPECT_FALSE(frame.can_flags.RTR) << "Frame RTR flag";
+    EXPECT_FALSE(frame.can_flags.BRS) << "Frame BRS flag";
+    EXPECT_FALSE(frame.can_flags.ESI) << "Frame ESI flag";
+    EXPECT_EQ(frame.time_to_live, 0U) << "Frame time to live";
+    EXPECT_EQ(frame.xl_control.payload_type, 0U) << "Frame XL control payload type";
+    EXPECT_EQ(frame.xl_control.virtual_can_network_id, 0U) << "Frame XL control virtual can network id";
+    EXPECT_EQ(frame.xl_control.addressing_field, 0U) << "Frame XL control addressing field";
+    EXPECT_EQ(frame.payload.size(), 0U) << "Frame payload is empty";
+
+    // set everything!
+    frame.can_identifier = 0xFFFFU;
+    frame.can_flags.IDE = true;
+    frame.can_flags.TTL = true;
+    frame.can_flags.XLF = true;
+    frame.can_flags.WA = true;
+    frame.can_flags.FDF = true;
+    frame.can_flags.RTR = true;
+    frame.can_flags.BRS = true;
+    frame.can_flags.ESI = true;
+    frame.time_to_live = 0xFFU;
+    frame.xl_control.payload_type = 0xFFU;
+    frame.xl_control.virtual_can_network_id = 0xFFU;
+    frame.xl_control.addressing_field = 0xFFFFFFFFU;
+    etl::span<uint8_t> payload_span(new uint8_t[10U], 10U);
+    frame.payload = payload_span;
+
+    // reset should clear everything!
+    frame.Reset();
+    EXPECT_EQ(frame.can_identifier, 0U) << "Frame identifier";
+    EXPECT_FALSE(frame.can_flags.IDE) << "Frame IDE flag";
+    EXPECT_FALSE(frame.can_flags.TTL) << "Frame TTL flag";
+    EXPECT_FALSE(frame.can_flags.XLF) << "Frame XLF flag";
+    EXPECT_FALSE(frame.can_flags.WA) << "Frame WA flag";
+    EXPECT_FALSE(frame.can_flags.FDF) << "Frame FDF flag";
+    EXPECT_FALSE(frame.can_flags.RTR) << "Frame RTR flag";
+    EXPECT_FALSE(frame.can_flags.BRS) << "Frame BRS flag";
+    EXPECT_FALSE(frame.can_flags.ESI) << "Frame ESI flag";
+    EXPECT_EQ(frame.time_to_live, 0U) << "Frame time to live";
+    EXPECT_EQ(frame.xl_control.payload_type, 0U) << "Frame XL control payload type";
+    EXPECT_EQ(frame.xl_control.virtual_can_network_id, 0U) << "Frame XL control virtual can network id";
+    EXPECT_EQ(frame.xl_control.addressing_field, 0U) << "Frame XL control addressing field";
+    EXPECT_EQ(frame.payload.size(), 0U) << "Frame payload is empty";
+}
+
+TEST(SpIOpen_Frame, HeaderLength) {
+    Frame frame;
+    EXPECT_EQ(frame.GetHeaderLength(), 4U) << "Empty frame";
+
+    frame.Reset();
+    frame.can_flags.IDE = true;
+    EXPECT_EQ(frame.GetHeaderLength(), 6U) << "Frame with IDE flag";
+
+    frame.Reset();
+    frame.can_flags.TTL = true;
+    EXPECT_EQ(frame.GetHeaderLength(), 5U) << "Frame with TTL flag";
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    frame.Reset();
+    frame.can_flags.FDF = true;
+    EXPECT_EQ(frame.GetHeaderLength(), 4U) << "Frame with FDF flag";
+#endif
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    frame.Reset();
+    frame.can_flags.XLF = true;
+    EXPECT_EQ(frame.GetHeaderLength(), 12U) << "Frame with XLF flag";
+#endif
+}
+
+TEST(SpIOpen_Frame, FrameLength) {
+    Frame frame;
+    uint8_t frame_data[2050U];
+    frame.payload = etl::span<uint8_t>(frame_data, 0);
+    size_t frame_length = 0U;
+
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Empty frame";
+    EXPECT_EQ(frame_length, 8U) << "Empty frame";
+
+    frame.Reset();
+    frame.payload = etl::span<uint8_t>(frame_data, 1);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 1B payload";
+    EXPECT_EQ(frame_length, 9U) << "Frame with 1B payload";
+    frame.can_flags.WA = true;
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 1B payload and WA flag";
+    EXPECT_EQ(frame_length, 10U) << "Frame with 1B payload and WA flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 9);
+    EXPECT_FALSE(frame.TryGetFrameLength(frame_length)) << "Frame with 9B payload in CC mode";
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    frame.Reset();
+    frame.payload = etl::span<uint8_t>(frame_data, 8);
+    frame.can_flags.FDF = true;
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 8B payload and FDF flag";
+    EXPECT_EQ(frame_length, 16U) << "Frame with 8B payload and FDF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 12);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 12B payload and FDF flag";
+    EXPECT_EQ(frame_length, 22U) << "Frame with 12B payload and FDF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 14);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 14B payload + padding and FDF flag";
+    EXPECT_EQ(frame_length, 26U) << "Frame with 14B payload + padding and FDF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 64);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 64B payload and FDF flag";
+    EXPECT_EQ(frame_length, 74U) << "Frame with 64B payload and FDF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 65);
+    EXPECT_FALSE(frame.TryGetFrameLength(frame_length)) << "Frame with 65B payload and FDF flag";
+#endif
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    frame.Reset();
+    frame.payload = etl::span<uint8_t>(frame_data, 8);
+    frame.can_flags.XLF = true;
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 8B payload and XLF flag";
+    EXPECT_EQ(frame_length, 24U) << "Frame with 8B payload and XLF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 12);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 12B payload and XLF flag";
+    EXPECT_EQ(frame_length, 30U) << "Frame with 12B payload and XLF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 64);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 64B payload and XLF flag";
+    EXPECT_EQ(frame_length, 82U) << "Frame with 64B payload and XLF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 2048);
+    EXPECT_TRUE(frame.TryGetFrameLength(frame_length)) << "Frame with 2048B payload and XLF flag";
+    EXPECT_EQ(frame_length, 2066U) << "Frame with 2048B payload and XLF flag";
+    frame.payload = etl::span<uint8_t>(frame_data, 2049);
+    EXPECT_FALSE(frame.TryGetFrameLength(frame_length)) << "Frame with 2049B payload and XLF flag";
+#endif
+}
+
+TEST(SpIOpen_Frame, DecrementAndCheckIfTimeToLiveExpired) {
+    Frame frame;
+    EXPECT_FALSE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Empty frame";
+    frame.can_flags.TTL = true;
+    EXPECT_TRUE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Frame with TTL flag and uninitialzied TTL";
+    frame.time_to_live = 2U;
+    EXPECT_FALSE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Frame with TTL flag and TTL=2";
+    EXPECT_TRUE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Frame with TTL flag and TTL=1";
+    EXPECT_TRUE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Frame with TTL flag and TTL=0";
+    frame.Reset();
+    frame.time_to_live = 2U;
+    EXPECT_FALSE(frame.DecrementAndCheckIfTimeToLiveExpired()) << "Frame without TTL flag and TTL=2";
+    EXPECT_EQ(frame.time_to_live, 2U) << "Frame should not decrement if TTL flag is not set";
+}

--- a/Libraries/SpIOpen_Frame/tests/spiopen_frame_writer_tests.cpp
+++ b/Libraries/SpIOpen_Frame/tests/spiopen_frame_writer_tests.cpp
@@ -1,0 +1,692 @@
+#include <etl/byte_stream.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "spiopen_frame.h"
+#include "spiopen_frame_format.h"
+#include "spiopen_frame_writer.h"
+
+using namespace spiopen;
+using namespace spiopen::format;
+using namespace spiopen::frame_writer;
+using namespace spiopen::frame_writer::impl;
+
+TEST(SpIOpen_FrameWriter, ValidateFrame) {
+    // --- Success: CC frame, empty payload, buffer large enough ---
+    {
+        Frame frame{};
+        frame.can_flags = {};
+        frame.payload = etl::span<uint8_t>();
+        uint8_t buffer[format::MAX_CAN_CC_FRAME_SIZE] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        ASSERT_TRUE(ret) << "ValidateFrame should succeed for valid CC frame with empty payload";
+    }
+
+    // --- Success: CC frame, max CC payload (8 bytes), buffer large enough ---
+    {
+        uint8_t payload_storage[MAX_CC_PAYLOAD_SIZE] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.payload = etl::span<uint8_t>(payload_storage, MAX_CC_PAYLOAD_SIZE);
+        uint8_t buffer[format::MAX_CAN_CC_FRAME_SIZE] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        ASSERT_TRUE(ret) << "ValidateFrame should succeed for CC frame with 8-byte payload";
+    }
+
+    // --- InvalidPayloadLength: CC frame with payload size > 8 ---
+    {
+        uint8_t payload_storage[9] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.payload = etl::span<uint8_t>(payload_storage, 9);
+        uint8_t buffer[format::MAX_CAN_CC_FRAME_SIZE + 10] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret) << "ValidateFrame should fail for CC payload > 8 bytes";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::InvalidPayloadLength);
+        }
+    }
+
+    // --- BufferTooShort: valid frame but stream has insufficient space ---
+    {
+        uint8_t payload_storage[2] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.payload = etl::span<uint8_t>(payload_storage, 2);
+        size_t frame_len = 0;
+        ASSERT_TRUE(frame.TryGetFrameLength(frame_len));
+        // CC 2-byte payload frame is e.g. preamble 2 + header 2 + can_id 2 + payload 2 + crc 2 = 10 bytes
+        const size_t too_small = frame_len > 1 ? frame_len - 1 : 1;
+        uint8_t buffer[32] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, too_small), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret) << "ValidateFrame should fail when stream has fewer bytes than frame length";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        }
+    }
+
+    // --- InvalidPayloadLength: FD not enabled but frame has FDF set (TryGetPayloadSectionLength fails) ---
+#ifndef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    {
+        uint8_t payload_storage[8] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.FDF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 8);
+        uint8_t buffer[format::MAX_CAN_CC_FRAME_SIZE] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret) << "ValidateFrame should fail when FD not supported and frame has FDF set";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::InvalidPayloadLength);
+        }
+    }
+#endif
+
+    // --- CanXlNotSupported: XL not enabled but frame has XLF set (when FD is enabled, TryGetPayloadSectionLength can
+    // succeed for XL) ---
+#if defined(CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE) && !defined(CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE)
+    {
+        uint8_t payload_storage[9] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 9);
+        uint8_t buffer[256] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret)
+            << "ValidateFrame should fail with CanXlNotSupported when XL not enabled and frame has XLF set";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::CanXlNotSupported);
+        }
+    }
+#endif
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    // --- InvalidPayloadLength: FD frame with payload > 64 bytes ---
+    {
+        uint8_t payload_storage[65] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.FDF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 65);
+        uint8_t buffer[512] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret) << "ValidateFrame should fail for FD payload > 64 bytes";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::InvalidPayloadLength);
+        }
+    }
+#endif
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+    // --- InvalidPayloadLength: XL frame with payload > 2048 bytes ---
+    {
+        uint8_t payload_storage[2049] = {0};
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 2049);
+        uint8_t buffer[4096] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = ValidateFrame(stream, frame);
+        EXPECT_FALSE(ret) << "ValidateFrame should fail for XL payload > 2048 bytes";
+        if (!ret) {
+            EXPECT_EQ(ret.error(), FrameWriteError::InvalidPayloadLength);
+        }
+    }
+#endif
+}
+
+static etl::span<const uint8_t> MakeCrcRegionFromStream(etl::byte_stream_writer& stream, size_t skip_bytes = 0) {
+    etl::span<char> used = stream.used_data();
+    const size_t n = used.size() > skip_bytes ? used.size() - skip_bytes : 0U;
+    return etl::span<const uint8_t>(reinterpret_cast<const uint8_t*>(used.data()) + skip_bytes, n);
+}
+
+TEST(SpIOpen_FrameWriter, WritePreamble) {
+    constexpr uint8_t kExpectedPreambleByte = PREAMBLE_BYTE;
+
+    {
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        ASSERT_TRUE(ret) << "WritePreamble should succeed with sufficient buffer";
+        EXPECT_EQ(stream.size_bytes(), PREAMBLE_SIZE);
+        EXPECT_EQ(buffer[0], kExpectedPreambleByte) << "first preamble byte should be PREAMBLE_BYTE";
+        EXPECT_EQ(buffer[1], kExpectedPreambleByte) << "second preamble byte should be PREAMBLE_BYTE";
+    }
+
+    {
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, sizeof(buffer) - 3), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        ASSERT_TRUE(ret) << "WritePreamble should succeed at offset";
+        EXPECT_EQ(stream.size_bytes(), PREAMBLE_SIZE);
+        EXPECT_EQ(buffer[3], kExpectedPreambleByte);
+        EXPECT_EQ(buffer[4], kExpectedPreambleByte);
+    }
+
+    {
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        EXPECT_FALSE(ret) << "WritePreamble should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 1U), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        EXPECT_FALSE(ret) << "WritePreamble should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, 1U), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        EXPECT_FALSE(ret) << "WritePreamble should fail when cursor near end";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 2, 0U), etl::endian::big);
+        auto ret = WritePreamble(stream);
+        EXPECT_FALSE(ret) << "WritePreamble should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+}
+
+TEST(SpIOpen_FrameWriter, WriteFormatHeader) {
+    uint8_t payload_storage[2] = {0};
+    Frame frame{};
+    frame.can_flags = {};
+    frame.can_flags.IDE = 0;
+    frame.can_flags.FDF = 0;
+    frame.can_flags.XLF = 0;
+    frame.can_flags.TTL = 0;
+    frame.can_flags.WA = 0;
+    frame.payload = etl::span<uint8_t>(payload_storage, 2);
+    uint8_t buffer[8] = {0};
+
+    {
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WriteFormatHeader(stream, frame);
+        ASSERT_TRUE(ret) << "WriteFormatHeader should succeed with sufficient buffer";
+        EXPECT_EQ(stream.size_bytes(), FORMAT_HEADER_SIZE);
+    }
+
+    {
+        uint8_t small_buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(small_buffer, 0U), etl::endian::big);
+        auto ret = WriteFormatHeader(stream, frame);
+        EXPECT_FALSE(ret) << "WriteFormatHeader should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t short_buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(short_buffer + 3, 1U), etl::endian::big);
+        auto ret = WriteFormatHeader(stream, frame);
+        EXPECT_FALSE(ret) << "WriteFormatHeader should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t short_buffer[5] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(short_buffer + 4, 1U), etl::endian::big);
+        auto ret = WriteFormatHeader(stream, frame);
+        EXPECT_FALSE(ret) << "WriteFormatHeader should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+}
+
+TEST(SpIOpen_FrameWriter, WriteCanIdentifier) {
+    constexpr uint32_t kStandardId = 0x7FFU;
+    constexpr uint8_t kStandardIdHigh = 0x07U;
+    constexpr uint8_t kStandardIdLow = 0xFFU;
+    constexpr uint32_t kExtendedId = 0x1FFFFFFFU;
+    constexpr uint8_t kExtendedIdHigh = 0x1FU;
+
+    {
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.IDE = 0;
+        frame.can_identifier = kStandardId;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        ASSERT_TRUE(ret) << "WriteCanIdentifier should succeed for standard ID";
+        EXPECT_EQ(stream.size_bytes(), CAN_IDENTIFIER_SIZE);
+        EXPECT_EQ(buffer[0], kStandardIdHigh) << "first CAN identifier byte should be high byte of standard identifier";
+        EXPECT_EQ(buffer[1], kStandardIdLow);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags = {};
+        frame.can_flags.IDE = 1;
+        frame.can_identifier = kExtendedId;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        ASSERT_TRUE(ret) << "WriteCanIdentifier should succeed for extended ID";
+        EXPECT_EQ(stream.size_bytes(), CAN_IDENTIFIER_SIZE + CAN_IDENTIFIER_EXTENSION_SIZE);
+        EXPECT_EQ(buffer[0], kExtendedIdHigh) << "first CAN identifier byte should be high byte of extended identifier";
+        EXPECT_EQ(buffer[1], 0xFFU);
+        EXPECT_EQ(buffer[2], 0xFFU);
+        EXPECT_EQ(buffer[3], 0xFFU);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.IDE = 0;
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        EXPECT_FALSE(ret) << "WriteCanIdentifier should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.IDE = 0;
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 1U), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        EXPECT_FALSE(ret) << "WriteCanIdentifier should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.IDE = 1;
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, 1U), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        EXPECT_FALSE(ret) << "WriteCanIdentifier should fail for extended when no room";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.IDE = 0;
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, 1U), etl::endian::big);
+        auto ret = WriteCanIdentifier(stream, frame);
+        EXPECT_FALSE(ret) << "WriteCanIdentifier should fail when cursor near end";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+}
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_XL_ENABLE
+TEST(SpIOpen_FrameWriter, WriteXlDataAndControl) {
+    constexpr uint8_t kPayloadType = 0x12;
+    constexpr uint8_t kVirtualCanNetworkId = 0x34;
+    constexpr uint32_t kAddressingField = 0x12345678U;
+
+    {
+        uint8_t payload_storage[10] = {0};
+        Frame frame{};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 10);
+        frame.xl_control.payload_type = kPayloadType;
+        frame.xl_control.virtual_can_network_id = kVirtualCanNetworkId;
+        frame.xl_control.addressing_field = kAddressingField;
+        uint8_t buffer[16] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WriteXlDataAndControl(stream, frame);
+        ASSERT_TRUE(ret) << "WriteXlDataAndControl should succeed with sufficient buffer";
+        EXPECT_EQ(stream.size_bytes(), 8U);
+        EXPECT_EQ(buffer[2], kPayloadType);
+        EXPECT_EQ(buffer[3], kVirtualCanNetworkId);
+        EXPECT_EQ(buffer[4], 0x12);
+        EXPECT_EQ(buffer[5], 0x34);
+        EXPECT_EQ(buffer[6], 0x56);
+        EXPECT_EQ(buffer[7], 0x78);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>();
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        auto ret = WriteXlDataAndControl(stream, frame);
+        EXPECT_FALSE(ret) << "WriteXlDataAndControl should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t payload_storage[1] = {0};
+        Frame frame{};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 1);
+        uint8_t buffer[10] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 5, 5U), etl::endian::big);
+        auto ret = WriteXlDataAndControl(stream, frame);
+        EXPECT_FALSE(ret) << "WriteXlDataAndControl should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+
+    {
+        uint8_t payload_storage[1] = {0};
+        Frame frame{};
+        frame.can_flags.XLF = 1;
+        frame.payload = etl::span<uint8_t>(payload_storage, 1);
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 8, 0U), etl::endian::big);
+        auto ret = WriteXlDataAndControl(stream, frame);
+        EXPECT_FALSE(ret) << "WriteXlDataAndControl should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+}
+#endif
+
+TEST(SpIOpen_FrameWriter, WriteTimeToLive) {
+    {
+        Frame frame{};
+        frame.can_flags.TTL = 1;
+        frame.time_to_live = 5;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WriteTimeToLive(stream, frame);
+        ASSERT_TRUE(ret) << "WriteTimeToLive should succeed when TTL set";
+        EXPECT_EQ(stream.size_bytes(), TIME_TO_LIVE_SIZE);
+        EXPECT_EQ(buffer[0], 5U) << "TTL byte should match frame.time_to_live";
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.TTL = 0;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, sizeof(buffer) - 3), etl::endian::big);
+        auto ret = WriteTimeToLive(stream, frame);
+        ASSERT_TRUE(ret) << "WriteTimeToLive should succeed when TTL not set";
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.TTL = 1;
+        frame.time_to_live = 1;
+        uint8_t buffer[1] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        auto ret = WriteTimeToLive(stream, frame);
+        EXPECT_FALSE(ret) << "WriteTimeToLive should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.TTL = 1;
+        frame.time_to_live = 1;
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 4, 0U), etl::endian::big);
+        auto ret = WriteTimeToLive(stream, frame);
+        EXPECT_FALSE(ret) << "WriteTimeToLive should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+}
+
+TEST(SpIOpen_FrameWriter, WritePayload) {
+    {
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>();
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        ASSERT_TRUE(ret) << "WritePayload should succeed with zero length";
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t payload[] = {0x01, 0x02, 0x03};
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload, 3);
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        ASSERT_TRUE(ret) << "WritePayload should succeed with payload data";
+        EXPECT_EQ(stream.size_bytes(), 3U);
+        EXPECT_EQ(buffer[0], 0x01);
+        EXPECT_EQ(buffer[1], 0x02);
+        EXPECT_EQ(buffer[2], 0x03);
+    }
+
+    {
+        uint8_t payload[] = {0xAB, 0, 0, 0};
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload, 4);
+        uint8_t buffer[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        ASSERT_TRUE(ret) << "WritePayload should succeed with payload and padding";
+        EXPECT_EQ(stream.size_bytes(), 4U);
+        EXPECT_EQ(buffer[0], 0xAB);
+        EXPECT_EQ(buffer[1], 0);
+        EXPECT_EQ(buffer[2], 0);
+        EXPECT_EQ(buffer[3], 0);
+    }
+
+    {
+        uint8_t payload[] = {0x01};
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload, 1);
+        uint8_t buffer[1] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        EXPECT_FALSE(ret) << "WritePayload should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t payload[] = {0x01, 0x02, 0x03};
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload, 3);
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 6, 2U), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        EXPECT_FALSE(ret) << "WritePayload should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+
+    {
+        uint8_t payload[] = {0x01, 0x02};
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload, 2);
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 3, 1U), etl::endian::big);
+        auto ret = WritePayload(stream, frame);
+        EXPECT_FALSE(ret) << "WritePayload should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+        EXPECT_EQ(stream.size_bytes(), 0U);
+    }
+}
+
+TEST(SpIOpen_FrameWriter, WriteCrc) {
+    {
+        uint8_t payload_storage[3] = {0};
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        ASSERT_TRUE(WritePreamble(stream));
+        stream.write_unchecked(static_cast<uint8_t>(0x01));
+        stream.write_unchecked(static_cast<uint8_t>(0x02));
+        stream.write_unchecked(static_cast<uint8_t>(0x03));
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload_storage, 3);
+        auto crc_region = MakeCrcRegionFromStream(stream, PREAMBLE_SIZE);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        ASSERT_TRUE(ret) << "WriteCrc should succeed for CRC16";
+        EXPECT_EQ(stream.size_bytes(), PREAMBLE_SIZE + 3U + SHORT_CRC_SIZE);
+    }
+
+#ifdef CONFIG_SPIOPEN_FRAME_CAN_FD_ENABLE
+    {
+        uint8_t payload_storage[9] = {0};
+        uint8_t buffer[16] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        ASSERT_TRUE(WritePreamble(stream));
+        for (uint8_t i = 1; i <= 9; ++i) {
+            stream.write_unchecked(i);
+        }
+        Frame frame{};
+        frame.can_flags.FDF = 1;  // FD frame so TryGetPayloadSectionLength accepts 9-byte payload
+        frame.payload = etl::span<uint8_t>(payload_storage, 9);
+        auto crc_region = MakeCrcRegionFromStream(stream, PREAMBLE_SIZE);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        ASSERT_TRUE(ret) << "WriteCrc should succeed for CRC32";
+        EXPECT_EQ(stream.size_bytes(), PREAMBLE_SIZE + 9U + LONG_CRC_SIZE);
+    }
+#endif
+
+    {
+        uint8_t payload_storage[1] = {0};
+        uint8_t buffer[2] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 0U), etl::endian::big);
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload_storage, 1);
+        auto crc_region = MakeCrcRegionFromStream(stream);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "WriteCrc should fail with zero-length buffer";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+
+    {
+        // Room for preamble + 1 byte (3 bytes used), but only 1 free; CRC16 needs 2 bytes so WriteCrc fails.
+        uint8_t payload_storage[1] = {0};
+        uint8_t buffer[5] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 4U), etl::endian::big);
+        ASSERT_TRUE(WritePreamble(stream));
+        stream.write_unchecked(static_cast<uint8_t>(1));
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload_storage, 1);
+        auto crc_region = MakeCrcRegionFromStream(stream, PREAMBLE_SIZE);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "WriteCrc should fail when buffer too short";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+
+    {
+        uint8_t payload_storage[9] = {0};
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 5, 3U), etl::endian::big);
+        ASSERT_TRUE(WritePreamble(stream));
+        stream.write_unchecked(static_cast<uint8_t>(1));
+        Frame frame{};
+        frame.can_flags.FDF = 1;  // FD frame so TryGetPayloadSectionLength accepts 9-byte payload
+        frame.payload = etl::span<uint8_t>(payload_storage, 9);
+        auto crc_region = MakeCrcRegionFromStream(stream, PREAMBLE_SIZE);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "WriteCrc should fail when no room for CRC32";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+
+    {
+        uint8_t payload_storage[1] = {0};
+        uint8_t buffer[4] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 2, 2U), etl::endian::big);
+        ASSERT_TRUE(WritePreamble(stream));
+        Frame frame{};
+        frame.payload = etl::span<uint8_t>(payload_storage, 1);
+        auto crc_region = MakeCrcRegionFromStream(stream, PREAMBLE_SIZE);
+        auto ret = WriteCrc(stream, frame, crc_region);
+        EXPECT_FALSE(ret) << "WriteCrc should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+}
+
+TEST(SpIOpen_FrameWriter, WriteFramePadding) {
+    {
+        Frame frame{};
+        frame.can_flags.WA = 1;
+        uint8_t buffer[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, sizeof(buffer)), etl::endian::big);
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        auto ret = WriteFramePadding(stream, frame);
+        ASSERT_TRUE(ret) << "WriteFramePadding should succeed when word align and odd length";
+        EXPECT_EQ(stream.size_bytes(), 3U + MAX_PADDING_SIZE);
+        EXPECT_EQ(buffer[3], 0);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.WA = 0;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 5, 3U), etl::endian::big);
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        auto ret = WriteFramePadding(stream, frame);
+        ASSERT_TRUE(ret) << "WriteFramePadding should succeed when word align disabled";
+        EXPECT_EQ(stream.size_bytes(), 3U);
+    }
+
+    {
+        Frame frame{};
+        frame.can_flags.WA = 1;
+        uint8_t buffer[8] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 2, 6U), etl::endian::big);
+        stream.write_unchecked(static_cast<uint16_t>(0));
+        auto ret = WriteFramePadding(stream, frame);
+        ASSERT_TRUE(ret) << "WriteFramePadding should succeed when length already even";
+        EXPECT_EQ(stream.size_bytes(), 2U);
+    }
+
+    {
+        // Stream with 3 bytes written (odd length after preamble) and 0 free: must write 1 padding byte but cannot.
+        Frame frame{};
+        frame.can_flags.WA = 1;
+        uint8_t buffer[3] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer, 3U), etl::endian::big);
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        auto ret = WriteFramePadding(stream, frame);
+        EXPECT_FALSE(ret) << "WriteFramePadding should fail when no room for padding byte";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+
+    {
+        // Stream with 1 byte written and 0 free (cursor at end): current_length underflows; implementation may or may
+        // not try to write.
+        Frame frame{};
+        frame.can_flags.WA = 1;
+        uint8_t buffer[5] = {0};
+        etl::byte_stream_writer stream(etl::span<uint8_t>(buffer + 4, 1U), etl::endian::big);
+        stream.write_unchecked(static_cast<uint8_t>(0));
+        auto ret = WriteFramePadding(stream, frame);
+        EXPECT_FALSE(ret) << "WriteFramePadding should fail when no room at cursor";
+        EXPECT_EQ(ret.error(), FrameWriteError::BufferTooShort);
+    }
+}

--- a/SpIOpen/Kconfig
+++ b/SpIOpen/Kconfig
@@ -1,0 +1,7 @@
+menu SpIOpen Protocol Features
+
+config SPIOPEN_CONFIGURABLE_FRAME_POOL
+    bool "Support configurable (non-static) spiopen frame pool"
+    default n
+    help
+        This allows a setting on the device to determine the size of the spiopen frame router pool, but requires heap allocation of the frame pool at initialization.

--- a/SpIOpen/README.md
+++ b/SpIOpen/README.md
@@ -1,0 +1,27 @@
+# SpIOpen
+
+Protocol for tunneling CAN frames over SPI Bus, specifically focused on CANOpen usage on industrial IO backplanes.
+
+## Bus Layout
+
+Unlike CAN, SpIOpen is primarily meant to act in a master/slave configuration as an industrial fieldbus.
+The master node transmits SpIOpen messages (frames) on a common drop-bus (one-to-many) to all slaves simultaneously.
+The slave nodes transmit their response SpIOpen messages (frames) on a daisy-chain bus (one-to-one) that propogates all messages towards the master.
+This allows fast time synchronization (SYNC messages from master) and physical position detection (TTL signal decremented on chain bus) of slaves while maintaining high data rates by avoiding electronic arbitration.
+
+## Frame Definition
+
+See @SpIOpen_Frame_Definition.md
+
+## Signals
+
+The SpIOpen protocol uses a subset of standard SPI signals, making it a unidirectional protocol:
+* Clock Signal (CLK) : Signals data validity on transition
+* Data Signal (MOSI) : Presents high or low signal at the time of clock transition
+
+Notes:
+* Without a chip select signal, bit-slip can occur. Slaves should be configured to reset all receive ports after the SPI bus has been idle for a certain amount of time.
+  * Question: how should this timeout be configured?
+
+# Contents
+

--- a/SpIOpen/include/spiopen_frame_pool.h
+++ b/SpIOpen/include/spiopen_frame_pool.h
@@ -1,0 +1,39 @@
+/*
+SpIOpen Frame Pool : Used to manage a pool of SpIOpen frames that is shared among multiple producers and consumers in a SpIOpen device.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once
+#include "spiopen_frame.h"
+
+
+namespace SpIOpen {
+
+
+    class FramePool {
+
+        public:
+            struct Config {
+                size_t max_can-cc_frames;
+                #ifdef CONFIG_SPIOPEN_CAN_FD_ENABLE
+                size_t max_can-fd_frames;
+                #endif
+                #ifdef CONFIG_SPIOPEN_CAN_XL_ENABLE
+                size_t max_can_xl_frames;
+                #endif
+            };
+
+            SpIOpenFramePool(const Config &config);
+            ~SpIOpenFramePool();
+            
+            Frame *GetFrame();
+            Frame *GetFrameFromISR(BaseType_t *pxHigherPriorityTaskWoken);
+            void ReleaseFrame(Frame *frame);
+            void ReleaseFrameFromISR(Frame *frame, BaseType_t *pxHigherPriorityTaskWoken);
+
+        private:
+            Config config_;
+            Frame::Header *frame;
+    };
+}

--- a/SpIOpen/include/spiopen_router.h
+++ b/SpIOpen/include/spiopen_router.h
@@ -1,0 +1,7 @@
+/*
+SpIOpen Frame Router : Used to link together multiple spiopen frame producers and consumers within one device.
+
+Copyright 2026 Andrew Burks, Burks Engineering
+SPDX-License-Identifier: Apache-2.0
+*/
+#pragma once


### PR DESCRIPTION
Implement #1 with Libraries/SpIOpen_Frame internal library:
* spiopen::format namespace with important protocol and frame constants (see FrameFormat.md)
* spiopen::Frame and spiopen::FrameBuffer classes to manage the data of a frame in a structured way and its relationship to a bytestream
* spiopen::algorithms which allows for target specific replacements of algorithms like CRCs with hardware accelerated options (see AlgorithmBackend.md)
* spiopen::frame_reader and spiopen::frame_writer namespaces with helper functions used to shuffle data between structured Frame objects and bytestreams
* Plenty of unit tests
* Lots of project structure for dev and test (cmake, Kconfig, devcontainer.json, tasks.json, dockerfile, clang-format, gitmodules, AGENTS.md, etc)